### PR TITLE
chore: disable npm lockfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,6 @@ node_modules
 !.flowconfig
 !.gitignore
 !.npmignore
+!.npmrc
 !.travis.yml
 !.README

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false


### PR DESCRIPTION
Use `.npmrc` to disable npm lockfile.