### PR TITLE
fix: respect options.host

### DIFF
--- a/src/classes/Agent.js
+++ b/src/classes/Agent.js
@@ -46,7 +46,7 @@ class Agent {
   }
 
   addRequest (request: *, configuration: *) {
-    const requestUrl = this.protocol + '//' + configuration.hostname + (configuration.port === 80 || configuration.port === 443 ? '' : ':' + configuration.port) + request.path;
+    const requestUrl = this.protocol + '//' + (configuration.hostname || configuration.host) + (configuration.port === 80 || configuration.port === 443 ? '' : ':' + configuration.port) + request.path;
 
     if (!this.isProxyConfigured()) {
       log.trace({


### PR DESCRIPTION
Respect both `options.host` and `options.hostname`. Even though `options.hostname` is an alias of `options.host`, it seems that `options.hostname` has higher priority if both are provided according to [http.request doc](https://nodejs.org/docs/latest-v10.x/api/http.html#http_http_request_options_callback) .
This fixes #10 