### PR TITLE
Enforce that all HTTP requests always use the global agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ global.GLOBAL_AGENT.eventEmitter.on('request', (request) => {
 
 ### How does it work?
 
-`global-agent` configures [`http.globalAgent`](https://nodejs.org/api/http.html#http_http_globalagent) and [`https.globalAgent`](https://nodejs.org/api/https.html#https_https_globalagent) to use a custom [Agent](https://nodejs.org/api/http.html#http_class_http_agent) for HTTP and HTTPS.
+`global-agent` configures [`http.globalAgent`](https://nodejs.org/api/http.html#http_http_globalagent) and [`https.globalAgent`](https://nodejs.org/api/https.html#https_https_globalagent) to use a custom [Agent](https://nodejs.org/api/http.html#http_class_http_agent) for HTTP and HTTPS, and ensures that all requests made with the built-in `http` and `https` modules use these agents.
 
 ### What versions of Node.js are supported?
 

--- a/src/factories/createGlobalProxyAgent.js
+++ b/src/factories/createGlobalProxyAgent.js
@@ -23,6 +23,12 @@ import type {
 } from '../types';
 import createProxyController from './createProxyController';
 
+// Save a reference to the original methods, that we might be overloading later
+const httpGet = http.get;
+const httpRequest = http.request;
+const httpsGet = https.get;
+const httpsRequest = https.request;
+
 const defaultConfigurationInput = {
   environmentVariableNamespace: undefined
 };
@@ -139,16 +145,16 @@ export default (configurationInput: ProxyAgentConfigurationInputType = defaultCo
     https.globalAgent = httpsAgent;
   } else if (semver.gte(process.version, 'v10.0.0')) {
     // $FlowFixMe
-    http.get = bindHttpMethod(http.get, httpAgent);
+    http.get = bindHttpMethod(httpGet, httpAgent);
 
     // $FlowFixMe
-    http.request = bindHttpMethod(http.request, httpAgent);
+    http.request = bindHttpMethod(httpRequest, httpAgent);
 
     // $FlowFixMe
-    https.get = bindHttpMethod(https.get, httpsAgent);
+    https.get = bindHttpMethod(httpsGet, httpsAgent);
 
     // $FlowFixMe
-    https.request = bindHttpMethod(https.request, httpsAgent);
+    https.request = bindHttpMethod(httpsRequest, httpsAgent);
   } else {
     log.warn('attempt to initialize global-agent in unsupported Node.js version was ignored');
   }

--- a/src/utilities/bindHttpMethod.js
+++ b/src/utilities/bindHttpMethod.js
@@ -32,14 +32,8 @@ export default (originalMethod: Function, agent: AgentType) => {
       callback = args[1];
     }
 
-    if (!options.agent) {
-      options.agent = agent;
-    }
-
-    // `request` module sets `agent` property to `http.globalAgent`/ `https.globalAgent` by default.
-    if (options.agent === http.globalAgent || options.agent === https.globalAgent) {
-      options.agent = agent;
-    }
+    // We *always* override the agent, even if explicitly set elsewhere
+    options.agent = agent;
 
     if (url) {
       // $FlowFixMe


### PR DESCRIPTION
Some libraries (e.g. [Stripe](https://github.com/stripe/stripe-node/blob/e542902dd8fbe591fe3c3ce07a7e89d1d60e4cf7/lib/StripeResource.js#L11-L12)) provide their own default agent, which has to be explicitly overridden.

To do this nicely, I'd like to override that agent with the exact same agent that global-agent is using, but that's not always available. If you're using Node >= v11.7.0 it's exposed as `{http,https}.globalAgent`, but in older Node versions it only exists as part of the binding of the http/https methods.

This PR exposes the agents as part of the global configuration, so that they can be retrieved as `global.GLOBAL_AGENT.HTTP_PROXY_AGENT` and `global.GLOBAL_AGENT.HTTPS_PROXY_AGENT`.