### PR TITLE
fix #25: propagate tls.connect options from the origin request to the proxy

### DIFF
--- a/src/classes/Agent.js
+++ b/src/classes/Agent.js
@@ -122,6 +122,34 @@ class Agent {
       proxy,
     };
 
+    // add optional tls options for https requests.
+    // @see https://nodejs.org/docs/latest-v12.x/api/https.html#https_https_request_url_options_callback :
+    // > The following additional options from tls.connect()
+    // >   - https://nodejs.org/docs/latest-v12.x/api/tls.html#tls_tls_connect_options_callback -
+    // > are also accepted:
+    // >   ca, cert, ciphers, clientCertEngine, crl, dhparam, ecdhCurve, honorCipherOrder,
+    // >   key, passphrase, pfx, rejectUnauthorized, secureOptions, secureProtocol, servername, sessionIdContext.
+    if (this.protocol === 'https:') {
+      connectionConfiguration.tls = {
+        ca: configuration.ca,
+        cert: configuration.cert,
+        ciphers: configuration.ciphers,
+        clientCertEngine: configuration.clientCertEngine,
+        crl: configuration.crl,
+        dhparam: configuration.dhparam,
+        ecdhCurve: configuration.ecdhCurve,
+        honorCipherOrder: configuration.honorCipherOrder,
+        key: configuration.key,
+        passphrase: configuration.passphrase,
+        pfx: configuration.pfx,
+        rejectUnauthorized: configuration.rejectUnauthorized,
+        secureOptions: configuration.secureOptions,
+        secureProtocol: configuration.secureProtocol,
+        servername: configuration.servername || connectionConfiguration.host,
+        sessionIdContext: configuration.sessionIdContext,
+      };
+    }
+
     // $FlowFixMe It appears that Flow is missing the method description.
     this.createConnection(connectionConfiguration, (error, socket) => {
       log.trace({

--- a/src/classes/Agent.js
+++ b/src/classes/Agent.js
@@ -120,6 +120,7 @@ class Agent {
       host: configuration.hostname || configuration.host,
       port: configuration.port || 80,
       proxy,
+      tls: {},
     };
 
     // add optional tls options for https requests.

--- a/src/classes/HttpsProxyAgent.js
+++ b/src/classes/HttpsProxyAgent.js
@@ -29,8 +29,7 @@ class HttpsProxyAgent extends Agent {
 
     socket.once('data', () => {
       const secureSocket = tls.connect({
-        rejectUnauthorized: false,
-        servername: configuration.host,
+        ... configuration.tls,
         socket,
       });
 

--- a/src/types.js
+++ b/src/types.js
@@ -19,9 +19,29 @@ export type ProxyConfigurationType = {|
   +port: number,
 |};
 
+export type TlsConfigurationType = {|
+  +ca?: string,
+  +cert?: string,
+  +ciphers?: string,
+  +clientCertEngine?: string,
+  +crl?: string,
+  +dhparam?: string,
+  +ecdhCurve?: string,
+  +honorCipherOrder?: boolean,
+  +key?: string,
+  +passphrase?: string,
+  +pfx?: string,
+  +rejectUnauthorized?: boolean,
+  +secureOptions?: number,
+  +secureProtocol?: string,
+  +servername?: string,
+  +sessionIdContext?: string,
+|};
+
 export type ConnectionConfigurationType = {|
   +host: string,
   +port: number,
+  +tls?: TlsConfigurationType,
   +proxy: ProxyConfigurationType,
 |};
 


### PR DESCRIPTION
fix #25 
This adds, when creating SSL connnection, any tls.connect() option that may have been set within the original request.
see:
* https://nodejs.org/docs/latest-v12.x/api/https.html#https_https_request_url_options_callback
* https://nodejs.org/docs/latest-v12.x/api/tls.html#tls_tls_createsecurecontext_options

NB : I tried to make some unit tests for this feature, but did not find a mean to intercept tls.connect() call with the dummy proxy :disappointed: 
Any help is welcome for that