### PR TITLE
feat: configurable rejectUnauthorized

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,11 +167,15 @@ Use [`roarr-cli`](https://github.com/gajus/roarr-cli) program to pretty-print th
  * @property environmentVariableNamespace Defines namespace of `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` environment variables. (Default: `GLOBAL_AGENT_`)
  * @property forceGlobalAgent Forces to use `global-agent` HTTP(S) agent even when request was explicitly constructed with another agent. (Default: `true`)
  * @property socketConnectionTimeout Destroys socket if connection is not established within the timeout. (Default: `60000`)
+ * @property rejectUnauthorized `false` - all invalid SSL certificates are ignored and no error is thrown.
+ *                              `true` - an error is thrown when an invalid SSL certificate is detected.
+ *                              (Default: `undefined`)
  */
 type ProxyAgentConfigurationInputType = {|
   +environmentVariableNamespace?: string,
   +forceGlobalAgent?: boolean,
   +socketConnectionTimeout?: number,
+  +rejectUnauthorized?: boolean,
 |};
 
 (configurationInput: ProxyAgentConfigurationInputType) => ProxyAgentConfigurationType;

--- a/src/factories/createGlobalProxyAgent.js
+++ b/src/factories/createGlobalProxyAgent.js
@@ -63,6 +63,7 @@ const createConfiguration = (configurationInput: ProxyAgentConfigurationInputTyp
   const defaultConfiguration = {
     environmentVariableNamespace: typeof environment.GLOBAL_AGENT_ENVIRONMENT_VARIABLE_NAMESPACE === 'string' ? environment.GLOBAL_AGENT_ENVIRONMENT_VARIABLE_NAMESPACE : 'GLOBAL_AGENT_',
     forceGlobalAgent: typeof environment.GLOBAL_AGENT_FORCE_GLOBAL_AGENT === 'string' ? parseBoolean(environment.GLOBAL_AGENT_FORCE_GLOBAL_AGENT) : true,
+    rejectUnauthorized: typeof environment.NODE_TLS_REJECT_UNAUTHORIZED === 'string' ? parseBoolean(environment.NODE_TLS_REJECT_UNAUTHORIZED) : undefined,
     socketConnectionTimeout: typeof environment.GLOBAL_AGENT_SOCKET_CONNECTION_TIMEOUT === 'string' ? Number.parseInt(environment.GLOBAL_AGENT_SOCKET_CONNECTION_TIMEOUT, 10) : defaultConfigurationInput.socketConnectionTimeout,
   };
 
@@ -132,6 +133,7 @@ export default (configurationInput: ProxyAgentConfigurationInputType = defaultCo
         getUrlProxy(getHttpProxy),
         http.globalAgent,
         configuration.socketConnectionTimeout,
+        configuration.rejectUnauthorized,
       );
     }
   };
@@ -152,6 +154,7 @@ export default (configurationInput: ProxyAgentConfigurationInputType = defaultCo
         getUrlProxy(getHttpsProxy),
         https.globalAgent,
         configuration.socketConnectionTimeout,
+        configuration.rejectUnauthorized,
       );
     }
   };

--- a/src/types.js
+++ b/src/types.js
@@ -57,10 +57,12 @@ export type ProxyAgentConfigurationInputType = {|
   +environmentVariableNamespace?: string,
   +forceGlobalAgent?: boolean,
   +socketConnectionTimeout?: number,
+  +rejectUnauthorized?: boolean,
 |};
 
 export type ProxyAgentConfigurationType = {|
   +environmentVariableNamespace: string,
   +forceGlobalAgent: boolean,
   +socketConnectionTimeout: number,
+  +rejectUnauthorized?: boolean,
 |};


### PR DESCRIPTION
This change makes it possible to configure `global-agent` to ignore certificate errors when the request-specific configuration is not provided.

## Problem

Axios does not allow its users to ignore SSL certificate errors, see axios/axios#535, axios/axios#1976 and [other issues](https://github.com/axios/axios/search?q=self-signed+certificate&type=Issues).

The recommended way around it is to configure Axios with an `https.Agent` with the appropriate setting:
```javascript
const instance = axios.create({
  httpsAgent: new https.Agent({  
    rejectUnauthorized: false
  })
});
```
However, because of [the way](https://github.com/axios/axios/blob/ffea03453f77a8176c51554d5f6c3c6829294649/lib/adapters/http.js#L81) Axios determines whether to use a `http.Agent` or a `https.Agent` based on the protocol of the destination url, this only works if both the proxy and the target URL follow the same, HTTPS protocol. 

To address the problem of Axios not supporting such protocol mismatch Global Agent could be used, but this then doesn't support ignoring certificate errors by means other than setting `NODE_TLS_REJECT_UNAUTHORIZED` to `0`, which is a [discouraged practice](https://nodejs.org/api/cli.html#cli_node_tls_reject_unauthorized_value).

## Proposed solution

Adding a new configuration option `rejectUnauthorized` to `bootstrap` routine would allow developers to provide a default setting for all the requests that go through `global-agent`, while allowing the more customisable HTTP clients like Sindre's [got](https://github.com/sindresorhus/got) to still override it on a per-request basis:

```javascript
bootstrap({ rejectUnauthorized: false });

const instance = axios.create();
```

## Alternatives considered

While it is possible to force Global Agent to `rejectUnauthorized` by specifying `NODE_TLS_REJECT_UNAUTHORIZED` equal `0`, I'd rather avoid that as this results in a warning emitted by Node.js:

```
(node:18596) Warning: Setting the NODE_TLS_REJECT_UNAUTHORIZED environment variable to '0' makes TLS connections and HTTPS requests insecure by disabling certificate verification.
```