### PR TITLE
NO_PROXY: allow separator with a comma and a space

### DIFF
--- a/src/utilities/isUrlMatchingNoProxy.js
+++ b/src/utilities/isUrlMatchingNoProxy.js
@@ -11,7 +11,7 @@ import {
 export default (subjectUrl: string, noProxy: string) => {
   const subjectUrlTokens = parseUrl(subjectUrl);
 
-  const rules = noProxy.split(/[\s,]/);
+  const rules = noProxy.split(/[\s,]+/);
 
   for (const rule of rules) {
     const ruleMatch = rule

--- a/test/global-agent/utilities/isUrlMatchingNoProxy.js
+++ b/test/global-agent/utilities/isUrlMatchingNoProxy.js
@@ -51,6 +51,14 @@ test('returns `true` if hosts match and ports do not match (port not present NO_
   t.assert(isUrlMatchingNoProxy('http://foo.com:8000/', 'foo.com'));
 });
 
-test('returns `true` if hosts match in one of multiple rules', (t) => {
+test('returns `true` if hosts match in one of multiple rules separated with a comma', (t) => {
   t.assert(isUrlMatchingNoProxy('http://foo.com/', 'bar.org,foo.com,baz.io'));
+});
+
+test('returns `true` if hosts match in one of multiple rules separated with a comma and a space', (t) => {
+  t.assert(isUrlMatchingNoProxy('http://foo.com/', 'bar.org, foo.com, baz.io'));
+});
+
+test('returns `true` if hosts match in one of multiple rules separated with a space', (t) => {
+  t.assert(isUrlMatchingNoProxy('http://foo.com/', 'bar.org foo.com baz.io'));
 });


### PR DESCRIPTION
This change will allow you to set multiple hosts in `NO_PROXY` separated with comma+space `, `.

[wget defines `no_proxy` as comma-separated list](https://www.gnu.org/software/wget/manual/html_node/Proxies.html), but other parsers allow for an extra space e.g.,:
- https://github.com/python/cpython/blob/49aec1a185bb2087fc4d846bd38d9150a357cfbd/Lib/urllib/request.py#L2540-L2541
- https://github.com/golang/go/blob/87c6fa4f473f178f7d931ddadd10c76444f8dc7b/src/vendor/golang.org/x/net/http/httpproxy/proxy.go#L216-L217
- https://github.com/curl/curl/blob/06a7f2745e58cd472894a2f4bd706c18a1acd03d/lib/url.c#L2181