### PR TITLE
Updating Agent.js class

### DIFF
--- a/src/classes/Agent.js
+++ b/src/classes/Agent.js
@@ -53,10 +53,13 @@ class Agent {
   }
   
   /**
-   * Method to add a list of certicates
-   * @param {*} ca list of ca certificates
+   * This method can be used to add ca certificates to the Agent
+   * @param {*} ca the certificates
    */
   addCACertificates(ca) {
+    //If there are already some ca certificates 
+    //then concat new certificate to the existing certificates
+    //otherwise directly assign new certificates to the ca property
     if (this.ca) {
       this.ca = this.ca.concat(ca);
     } else {
@@ -160,21 +163,12 @@ class Agent {
         key: configuration.key,
         passphrase: configuration.passphrase,
         pfx: configuration.pfx,
-        rejectUnauthorized: configuration.rejectUnauthorized,
+        rejectUnauthorized: configuration.rejectUnauthorized || (process.env.NODE_TLS_REJECT_UNAUTHORIZED !== '0'),
         secureOptions: configuration.secureOptions,
         secureProtocol: configuration.secureProtocol,
         servername: configuration.servername || connectionConfiguration.host,
         sessionIdContext: configuration.sessionIdContext,
       };
-
-      // This is not ideal because there is no way to override this setting using `tls` configuration if `NODE_TLS_REJECT_UNAUTHORIZED=0`.
-      // However, popular HTTP clients (such as https://github.com/sindresorhus/got) come with pre-configured value for `rejectUnauthorized`,
-      // which makes it impossible to override that value globally and respect `rejectUnauthorized` for specific requests only.
-      //
-      // eslint-disable-next-line no-process-env
-      if (typeof process.env.NODE_TLS_REJECT_UNAUTHORIZED === 'string' && boolean(process.env.NODE_TLS_REJECT_UNAUTHORIZED) === false) {
-        connectionConfiguration.tls.rejectUnauthorized = false;
-      }
     }
 
     // $FlowFixMe It appears that Flow is missing the method description.

--- a/src/classes/Agent.js
+++ b/src/classes/Agent.js
@@ -42,12 +42,26 @@ class Agent {
     getUrlProxy: GetUrlProxyMethodType,
     fallbackAgent: AgentType,
     socketConnectionTimeout: number,
+    ca: String
   ) {
     this.fallbackAgent = fallbackAgent;
     this.isProxyConfigured = isProxyConfigured;
     this.mustUrlUseProxy = mustUrlUseProxy;
     this.getUrlProxy = getUrlProxy;
     this.socketConnectionTimeout = socketConnectionTimeout;
+    this.ca = ca;
+  }
+  
+  /**
+   * Method to add a list of certicates
+   * @param {*} ca list of ca certificates
+   */
+  addCACertificates(ca) {
+    if (this.ca) {
+      this.ca = this.ca.concat(ca);
+    } else {
+      this.ca = ca;
+    }
   }
 
   addRequest (request: *, configuration: *) {
@@ -135,7 +149,7 @@ class Agent {
     // >   key, passphrase, pfx, rejectUnauthorized, secureOptions, secureProtocol, servername, sessionIdContext.
     if (this.protocol === 'https:') {
       connectionConfiguration.tls = {
-        ca: configuration.ca,
+        ca: configuration.ca || this.ca,
         cert: configuration.cert,
         ciphers: configuration.ciphers,
         clientCertEngine: configuration.clientCertEngine,


### PR DESCRIPTION
Added ca property to the Agent class so that at the time of creating global agent, user can pass ca in constructor.
Also added method to add ca certificates to the global agent after the instance has been created.
So in case request's configuration param do not contain ca property then by default agent's ca property can be used.