### PR TITLE
Remove unused core-js dependency to shrink the package by 80+%

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -14,11 +14,9 @@
     [
       "@babel/env",
       {
-        "corejs": "core-js@3",
         "targets": {
           "node": "12"
-        },
-        "useBuiltIns": "usage"
+        }
       }
     ]
   ]

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   },
   "dependencies": {
     "boolean": "^3.0.1",
-    "core-js": "^3.6.5",
     "es6-error": "^4.1.1",
     "matcher": "^3.0.0",
     "roarr": "^2.15.3",


### PR DESCRIPTION
Installing this package currently installs 9.3MB of dependencies. 7.7 of those megabytes (83% of this package's size) come from core-js, which isn't actually used at all.

I'm trying to make my deployables smaller, and I'd love to be able to avoid this extra unnecessary weight everywhere.

As evidence that it's not used at runtime:

* The only [references](https://github.com/gajus/global-agent/search?q=core-js) in this code base are in package.json and babelrc, so it's not used explicitly anywhere.
* When necessary, Babel would have automatically included a reference to core-js in the built code, but right now this package is targeting a modern node version and using no super-modern features, so it doesn't do that at all. You can check the built files [manually](https://unpkg.com/browse/global-agent@2.2.0/) to see this, or search them yourself by:
	* Making a new folder
	* `npm install global-agent`
	* `grep -R core-js .`
	* The only matching files are package.json, package-lock.json, and contents of core-js itself. There's no references in the global-agent code, because it's never actually imported.
* All the tests pass in this repo pass just fine in Node 10, without core-js installed.

I've removed it entirely since that seems like the safest way to handle this - in future, if you ever do want to use a super-new JS feature that node doesn't support yet, your tests (and presumably the Babel build?) will clearly fail as to warn you about this, and you can consider adding core-js back in or doing some other workaround.