### PR TITLE
Default rejectUnauthorized to true & match Node's NODE_TLS_REJECT_UNAUTHORIZED logic

### DIFF
--- a/src/classes/Agent.ts
+++ b/src/classes/Agent.ts
@@ -166,7 +166,7 @@ abstract class Agent {
         key: configuration.key,
         passphrase: configuration.passphrase,
         pfx: configuration.pfx,
-        rejectUnauthorized: configuration.rejectUnauthorized,
+        rejectUnauthorized: configuration.rejectUnauthorized ?? true,
         secureOptions: configuration.secureOptions,
         secureProtocol: configuration.secureProtocol,
         servername: configuration.servername ?? connectionConfiguration.host,

--- a/src/classes/Agent.ts
+++ b/src/classes/Agent.ts
@@ -1,9 +1,6 @@
 import type * as http from 'http';
 import type * as https from 'https';
 import {
-  boolean,
-} from 'boolean';
-import {
   serializeError,
 } from 'serialize-error';
 import Logger from '../Logger';
@@ -178,10 +175,7 @@ abstract class Agent {
       // which makes it impossible to override that value globally and respect `rejectUnauthorized` for specific requests only.
       if (
         // eslint-disable-next-line node/no-process-env
-        typeof process.env.NODE_TLS_REJECT_UNAUTHORIZED === 'string' &&
-
-        // eslint-disable-next-line node/no-process-env
-        boolean(process.env.NODE_TLS_REJECT_UNAUTHORIZED) === false
+        process.env.NODE_TLS_REJECT_UNAUTHORIZED === '0'
       ) {
         // @ts-expect-error seems like we are using wrong guard for this change that does not align with secureEndpoint
         connectionConfiguration.tls.rejectUnauthorized = false;


### PR DESCRIPTION
This fixes two security issues (public as they're already in discussion elsewhere in this repo):

1. The current behaviour, with versions of Node released up until today, which disabled TLS validation by default.
2. The NODE_TLS_REJECT_UNAUTHORIZED variable logic looks for any falsey value, when it should just look for `'0'`, like Node.js does. Currently an empty NODE_TLS_REJECT_UNAUTHORIZED variable will unexpectedly disable TLS verification.

These are a security issue ([more discussion](https://github.com/gajus/global-agent/pull/27#issuecomment-886776123)), but the main cause of the first one was that Node treated `rejectUnauthorized: undefined` as `rejectUnauthorized: false`. I reported that to the Node team as a security vulnerability there (CVE-2021-22939) and it's [now fixed](https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V16.md#16.6.2) in all the latest node releases.

That means in the very latest Node.js version, that first bug doesn't exist, and TLS _is_ enabled by default. This PR fixes it anyway though, to remove security risks when using global-agent with older node versions, and to make the behaviour consistent everywhere. This is basically the fix from #27, but note that it's using `??` instead of `||` (which would make passing `false` completely impossible).

The second fix is simpler: instead of using `boolean()`, we just need to check for the right string value. This exactly matches node's logic (which is [here](https://github.com/nodejs/node/blob/1bbe66f432591aea83555d27dd76c55fea040a0d/lib/internal/options.js#L38)), so that everything is consistently secured everywhere.