### PR TITLE
feat: Added functions to configure ca certificate to the global-agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,52 @@ type ProxyAgentConfigurationInputType = {|
 |`HTTPS_PROXY`|Yes|Sets a distinct proxy to use for HTTPS requests.|
 |`NO_PROXY`|Yes|Specifies a pattern of URLs that should be excluded from proxying. See [Exclude URLs](#exclude-urls).|
 
+## Certificate Authority (CA)
+
+### `addCACertificates`
+This method can be accessed using https to add CA certificates to the global-agent.
+
+Uses:
+```js
+if (typeof https.globalAgent.addCACertificates === 'function') {
+  //certificate - an array of ca certificates to be added to the global-agent
+  https.globalAgent.addCACertificates(certificate);
+}
+```
+
+Method Definition:
+```js
+/**
+ * This method can be used to add an array of ca certificates
+ * @param {*} ca an array of ca certificates
+ */
+addCACertificates (ca) {
+  // Concat valid ca certificates with the existing ca certificates.
+  if (ca) {
+    this.ca = this.ca.concat(ca);
+  }
+}
+```
+
+### `clearCACertificates`
+This method can be accessed using https to clear existing CA certificates from global-agent.
+
+Uses:
+```js
+if (typeof https.globalAgent.clearCACertificates === 'function') {
+  https.globalAgent.clearCACertificates();
+}
+```
+Method Definition:
+```js
+/**
+ * Clears existing CA Certificates
+ */
+clearCACertificates () {
+  this.ca = [];
+}
+```
+
 ## Supported libraries
 
 `global-agent` works with all libraries that internally use [`http.request`](https://nodejs.org/api/http.html#http_http_request_options_callback).

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Use [`roarr-cli`](https://github.com/gajus/roarr-cli) program to pretty-print th
  * @property environmentVariableNamespace Defines namespace of `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` environment variables. (Default: `GLOBAL_AGENT_`)
  * @property forceGlobalAgent Forces to use `global-agent` HTTP(S) agent even when request was explicitly constructed with another agent. (Default: `true`)
  * @property socketConnectionTimeout Destroys socket if connection is not established within the timeout. (Default: `60000`)
- * @property ca An array of CA certificates that is trusted for secure connections to the registry.
+ * @property ca An array of CA certificates that is trusted for secure connections to the registry. (Default: '[]')
  */
 type ProxyAgentConfigurationInputType = {|
   +environmentVariableNamespace?: string,

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ Method Definition:
  * This method can be used to add an array of ca certificates
  * @param {*} ca an array of ca certificates
  */
-addCACertificates (ca) {
+addCACertificates (ca: object) {
   // Concat valid ca certificates with the existing ca certificates.
   if (ca) {
     this.ca = this.ca.concat(ca);

--- a/README.md
+++ b/README.md
@@ -227,13 +227,17 @@ public addCACertificates (ca: string[] | string) {
   } else if (this.ca) {
     if (typeof ca === typeof this.ca) {
       // concat valid ca certificates with the existing certificates,
-      this.ca = this.ca.concat(ca);
+      if (typeof this.ca === 'string') {
+        this.ca = this.ca.concat(ca as string);
+      } else {
+        this.ca = this.ca.concat(ca as string[]);
+      }
     } else {
       log.error('Input ca certificate type mismatched with existing ca certificate type');
     }
   } else {
     this.ca = ca;
-  }  
+  }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -166,13 +166,13 @@ Use [`roarr-cli`](https://github.com/gajus/roarr-cli) program to pretty-print th
  * @property environmentVariableNamespace Defines namespace of `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` environment variables. (Default: `GLOBAL_AGENT_`)
  * @property forceGlobalAgent Forces to use `global-agent` HTTP(S) agent even when request was explicitly constructed with another agent. (Default: `true`)
  * @property socketConnectionTimeout Destroys socket if connection is not established within the timeout. (Default: `60000`)
- * @property ca An array of CA certificates that is trusted for secure connections to the registry (Default: []).
+ * @property ca An array of CA certificates that is trusted for secure connections to the registry.
  */
 type ProxyAgentConfigurationInputType = {|
   +environmentVariableNamespace?: string,
   +forceGlobalAgent?: boolean,
   +socketConnectionTimeout?: number,
-  +ca?: object,
+  +ca?: string[],
 |};
 
 (configurationInput: ProxyAgentConfigurationInputType) => ProxyAgentConfigurationType;

--- a/README.md
+++ b/README.md
@@ -166,13 +166,13 @@ Use [`roarr-cli`](https://github.com/gajus/roarr-cli) program to pretty-print th
  * @property environmentVariableNamespace Defines namespace of `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` environment variables. (Default: `GLOBAL_AGENT_`)
  * @property forceGlobalAgent Forces to use `global-agent` HTTP(S) agent even when request was explicitly constructed with another agent. (Default: `true`)
  * @property socketConnectionTimeout Destroys socket if connection is not established within the timeout. (Default: `60000`)
- * @property ca An array of CA certificates that is trusted for secure connections to the registry. (Default: '[]')
+ * @property ca Single CA certificate or an array of CA certificates that is trusted for secure connections to the registry.
  */
 type ProxyAgentConfigurationInputType = {|
   +environmentVariableNamespace?: string,
   +forceGlobalAgent?: boolean,
   +socketConnectionTimeout?: number,
-  +ca?: string[],
+  +ca?: string[] | string,
 |};
 
 (configurationInput: ProxyAgentConfigurationInputType) => ProxyAgentConfigurationType;
@@ -218,14 +218,22 @@ if (typeof https.globalAgent.addCACertificates === 'function') {
 Method Definition:
 ```js
 /**
- * This method can be used to add an array of ca certificates
- * @param {*} ca an array of ca certificates
+ * This method can be used to append new ca certificates to existing ca certificates
+ * @param {string | string[]} ca a ca certificate or an array of ca certificates
  */
-addCACertificates (ca: object) {
-  // Concat valid ca certificates with the existing ca certificates.
-  if (ca) {
-    this.ca = this.ca.concat(ca);
-  }
+public addCACertificates (ca: string[] | string) {
+  if (!ca) {
+    log.error('Invalid input ca certificate');
+  } else if (this.ca) {
+    if (typeof ca === typeof this.ca) {
+      // concat valid ca certificates with the existing certificates,
+      this.ca = this.ca.concat(ca);
+    } else {
+      log.error('Input ca certificate type mismatched with existing ca certificate type');
+    }
+  } else {
+    this.ca = ca;
+  }  
 }
 ```
 
@@ -241,10 +249,11 @@ if (typeof https.globalAgent.clearCACertificates === 'function') {
 Method Definition:
 ```js
 /**
- * Clears existing CA Certificates
+ * This method clears existing CA Certificates.
+ * It sets ca to undefined
  */
-clearCACertificates () {
-  this.ca = [];
+public clearCACertificates () {
+  this.ca = undefined;
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ Method Definition:
 ```js
 /**
  * This method can be used to append new ca certificates to existing ca certificates
- * @param {string | string[]} ca a ca certificate or an array of ca certificates
+ * @param {string[] | string} ca a ca certificate or an array of ca certificates
  */
 public addCACertificates (ca: string[] | string) {
   if (!ca) {

--- a/README.md
+++ b/README.md
@@ -166,11 +166,13 @@ Use [`roarr-cli`](https://github.com/gajus/roarr-cli) program to pretty-print th
  * @property environmentVariableNamespace Defines namespace of `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` environment variables. (Default: `GLOBAL_AGENT_`)
  * @property forceGlobalAgent Forces to use `global-agent` HTTP(S) agent even when request was explicitly constructed with another agent. (Default: `true`)
  * @property socketConnectionTimeout Destroys socket if connection is not established within the timeout. (Default: `60000`)
+ * @property ca An array of CA certificates that is trusted for secure connections to the registry (Default: []).
  */
 type ProxyAgentConfigurationInputType = {|
   +environmentVariableNamespace?: string,
   +forceGlobalAgent?: boolean,
   +socketConnectionTimeout?: number,
+  +ca?: object,
 |};
 
 (configurationInput: ProxyAgentConfigurationInputType) => ProxyAgentConfigurationType;

--- a/src/classes/Agent.ts
+++ b/src/classes/Agent.ts
@@ -70,7 +70,7 @@ abstract class Agent {
     this.mustUrlUseProxy = mustUrlUseProxy;
     this.getUrlProxy = getUrlProxy;
     this.socketConnectionTimeout = socketConnectionTimeout;
-    this.ca = ca || [];
+    this.ca = ca;
   }
 
   /**

--- a/src/classes/Agent.ts
+++ b/src/classes/Agent.ts
@@ -51,7 +51,7 @@ abstract class Agent {
 
   public socketConnectionTimeout: number;
 
-  public ca: string | string[] | undefined;
+  public ca: string[] | string | undefined;
 
   public constructor (
     isProxyConfigured: IsProxyConfiguredMethodType,
@@ -59,7 +59,7 @@ abstract class Agent {
     getUrlProxy: GetUrlProxyMethodType,
     fallbackAgent: AgentType,
     socketConnectionTimeout: number,
-    ca: string | string[] | undefined,
+    ca: string[] | string | undefined,
   ) {
     this.fallbackAgent = fallbackAgent;
     this.isProxyConfigured = isProxyConfigured;
@@ -71,9 +71,9 @@ abstract class Agent {
 
   /**
    * This method can be used to append new ca certificates to existing ca certificates
-   * @param {string | string[]} ca a ca certificate or an array of ca certificates
+   * @param {string[] | string} ca a ca certificate or an array of ca certificates
    */
-  public addCACertificates (ca: string | string[]) {
+  public addCACertificates (ca: string[] | string) {
     if (!ca) {
       log.error('Invalid input ca certificate');
     } else if (this.ca) {
@@ -85,7 +85,7 @@ abstract class Agent {
       }
     } else {
       this.ca = ca;
-    }  
+    }
   }
 
   /**

--- a/src/classes/Agent.ts
+++ b/src/classes/Agent.ts
@@ -53,9 +53,9 @@ abstract class Agent {
   public getUrlProxy: GetUrlProxyMethodType;
 
   public socketConnectionTimeout: number;
-  
+
   // ca property is an array of ca certificates
-  public ca: Array<string>;
+  public ca: string[];
 
   public constructor (
     isProxyConfigured: IsProxyConfiguredMethodType,
@@ -72,7 +72,7 @@ abstract class Agent {
     this.socketConnectionTimeout = socketConnectionTimeout;
     this.ca = ca || [];
   }
-  
+
   /**
    * This method can be used to add an array of ca certificates
    * @param {string[]} ca an array of ca certificates
@@ -95,7 +95,7 @@ abstract class Agent {
    * Evaluate value for tls reject unauthorized variable
    */
   public getRejectUnauthorized () {
-    // eslint-disable-next-line no-process-env
+    // eslint-disable-next-line node/no-process-env
     const rejectUnauthorized = process.env.NODE_TLS_REJECT_UNAUTHORIZED;
 
     return typeof rejectUnauthorized === 'undefined' ? true : boolean(rejectUnauthorized) !== false;
@@ -188,7 +188,7 @@ abstract class Agent {
     // >   key, passphrase, pfx, rejectUnauthorized, secureOptions, secureProtocol, servername, sessionIdContext.
     if (configuration.secureEndpoint) {
       connectionConfiguration.tls = {
-        ca: configuration.ca || this.ca,
+        ca: configuration.ca ?? this.ca,
         cert: configuration.cert,
         ciphers: configuration.ciphers,
         clientCertEngine: configuration.clientCertEngine,
@@ -199,7 +199,7 @@ abstract class Agent {
         key: configuration.key,
         passphrase: configuration.passphrase,
         pfx: configuration.pfx,
-        rejectUnauthorized: configuration.rejectUnauthorized || this.getRejectUnauthorized(),
+        rejectUnauthorized: configuration.rejectUnauthorized ?? this.getRejectUnauthorized(),
         secureOptions: configuration.secureOptions,
         secureProtocol: configuration.secureProtocol,
         servername: configuration.servername ?? connectionConfiguration.host,

--- a/src/classes/Agent.ts
+++ b/src/classes/Agent.ts
@@ -95,12 +95,13 @@ abstract class Agent {
     // eslint-disable-next-line node/no-process-env
     const rejectUnauthorized = process.env.NODE_TLS_REJECT_UNAUTHORIZED;    
     let returnValue = false;
-
-    if (typeof rejectUnauthorized === "boolean") {
+    if (typeof rejectUnauthorized === 'undefined') {
+      returnValue = true;
+    } else if (typeof rejectUnauthorized === 'boolean') {
       returnValue = rejectUnauthorized;
-    } else if (typeof rejectUnauthorized === "number") {
+    } else if (typeof rejectUnauthorized === 'number') {
       returnValue = rejectUnauthorized === 1;
-    } else if (typeof rejectUnauthorized === "string") {
+    } else if (typeof rejectUnauthorized === 'string') {
       returnValue = ['true', 't', 'yes', 'y', 'on', '1'].includes(rejectUnauthorized.trim().toLowerCase());
     }
 

--- a/src/classes/Agent.ts
+++ b/src/classes/Agent.ts
@@ -93,9 +93,18 @@ abstract class Agent {
    */
   public getRejectUnauthorized () {
     // eslint-disable-next-line node/no-process-env
-    const rejectUnauthorized = process.env.NODE_TLS_REJECT_UNAUTHORIZED;
+    const rejectUnauthorized = process.env.NODE_TLS_REJECT_UNAUTHORIZED;    
+    boolean returnValue = false;
 
-    return (typeof rejectUnauthorized === 'undefined' || rejectUnauthorized === '1' || rejectUnauthorized === 'yes' || rejectUnauthorized === 'true');
+    if (typeof rejectUnauthorized === boolean) {
+      returnValue = rejectUnauthorized
+    } else if (typeof rejectUnauthorized === number) {
+      returnValue = rejectUnauthorized === 1
+    } else if (typeof rejectUnauthorized === string){
+      returnValue = ['true', 't', 'yes', 'y', 'on', '1'].includes(rejectUnauthorized.trim().toLowerCase());
+    }
+
+    return returnValue;
   }
 
   public abstract createConnection (configuration: ConnectionConfigurationType, callback: ConnectionCallbackType): void;

--- a/src/classes/Agent.ts
+++ b/src/classes/Agent.ts
@@ -52,7 +52,7 @@ abstract class Agent {
   public socketConnectionTimeout: number;
 
   // ca property is an array of ca certificates
-  public ca: string[];
+  public ca: string | string[] | undefined;
 
   public constructor (
     isProxyConfigured: IsProxyConfiguredMethodType,
@@ -60,7 +60,7 @@ abstract class Agent {
     getUrlProxy: GetUrlProxyMethodType,
     fallbackAgent: AgentType,
     socketConnectionTimeout: number,
-    ca: string[],
+    ca: string | string[] | undefined,
   ) {
     this.fallbackAgent = fallbackAgent;
     this.isProxyConfigured = isProxyConfigured;
@@ -72,20 +72,25 @@ abstract class Agent {
 
   /**
    * This method can be used to add an array of ca certificates
-   * @param {string[]} ca an array of ca certificates
+   * @param {string | string[]} ca single ca certificate or an array of ca certificates
    */
-  public addCACertificates (ca: string[]) {
+  public addCACertificates (ca: string | string[]) {
     // concat valid ca certificates with the existing certificates,
     if (ca) {
-      this.ca = this.ca.concat(ca);
+      if(this.ca) {
+        this.ca = this.ca.concat(ca);
+      } else {
+        this.ca = ca;
+      }
     }
   }
 
   /**
-   * Clears existing CA Certificates
+   * Clears existing CA Certificates.
+   * It sets ca to undefined
    */
   public clearCACertificates () {
-    this.ca = [];
+    this.ca = undefined;
   }
 
   /**

--- a/src/classes/Agent.ts
+++ b/src/classes/Agent.ts
@@ -95,7 +95,7 @@ abstract class Agent {
     // eslint-disable-next-line node/no-process-env
     const rejectUnauthorized = process.env.NODE_TLS_REJECT_UNAUTHORIZED;
 
-    return typeof rejectUnauthorized === 'undefined' ? true : boolean(rejectUnauthorized) !== false;
+    return (typeof rejectUnauthorized === 'undefined' || rejectUnauthorized === '1' || rejectUnauthorized === 'yes' || rejectUnauthorized === 'true');
   }
 
   public abstract createConnection (configuration: ConnectionConfigurationType, callback: ConnectionCallbackType): void;

--- a/src/classes/Agent.ts
+++ b/src/classes/Agent.ts
@@ -51,7 +51,6 @@ abstract class Agent {
 
   public socketConnectionTimeout: number;
 
-  // ca property is an array of ca certificates
   public ca: string | string[] | undefined;
 
   public constructor (
@@ -71,8 +70,8 @@ abstract class Agent {
   }
 
   /**
-   * This method can be used to add an array of ca certificates
-   * @param {string | string[]} ca single ca certificate or an array of ca certificates
+   * This method can be used to append new ca certificates to existing ca certificates
+   * @param {string | string[]} ca a ca certificate or an array of ca certificates
    */
   public addCACertificates (ca: string | string[]) {
     // concat valid ca certificates with the existing certificates,
@@ -86,7 +85,7 @@ abstract class Agent {
   }
 
   /**
-   * Clears existing CA Certificates.
+   * This method clears existing CA Certificates.
    * It sets ca to undefined
    */
   public clearCACertificates () {

--- a/src/classes/Agent.ts
+++ b/src/classes/Agent.ts
@@ -79,9 +79,13 @@ abstract class Agent {
     } else if (this.ca) {
       if (typeof ca === typeof this.ca) {
         // concat valid ca certificates with the existing certificates,
-        this.ca = this.ca.concat(ca);
+        if (typeof this.ca === 'string') {
+          this.ca = this.ca.concat(ca as string);
+        } else {
+          this.ca = this.ca.concat(ca as string[]);
+        }
       } else {
-        log.error(`Input ca certificate's type mismatched with existing ca certificate's type`);
+        log.error('Input ca certificate type mismatched with existing ca certificate type');
       }
     } else {
       this.ca = ca;

--- a/src/classes/Agent.ts
+++ b/src/classes/Agent.ts
@@ -74,12 +74,14 @@ abstract class Agent {
    * @param {string | string[]} ca a ca certificate or an array of ca certificates
    */
   public addCACertificates (ca: string | string[]) {
-    // concat valid ca certificates with the existing certificates,
-    if (this.ca) {
+    if (!ca) {
+      log.error("Invalid input ca certificate");
+    } else if (this.ca) {
       if (typeof ca === typeof this.ca) {
+        // concat valid ca certificates with the existing certificates,
         this.ca = this.ca.concat(ca);
       } else {
-        log.error("Input ca type mismatched with existing ca type");
+        log.error("Input ca certificate's type mismatched with existing ca certificate's type");
       }
     } else {
       this.ca = ca;

--- a/src/classes/Agent.ts
+++ b/src/classes/Agent.ts
@@ -81,7 +81,7 @@ abstract class Agent {
         // concat valid ca certificates with the existing certificates,
         this.ca = this.ca.concat(ca);
       } else {
-        log.error('Input ca certificate type mismatched with existing ca certificate type');
+        log.error(`Input ca certificate's type mismatched with existing ca certificate's type`);
       }
     } else {
       this.ca = ca;

--- a/src/classes/Agent.ts
+++ b/src/classes/Agent.ts
@@ -94,10 +94,8 @@ abstract class Agent {
   public getRejectUnauthorized () {
     // eslint-disable-next-line node/no-process-env
     const rejectUnauthorized = process.env.NODE_TLS_REJECT_UNAUTHORIZED;
-    let returnValue = false;
-    if (typeof rejectUnauthorized === 'undefined') {
-      returnValue = true;
-    } else if (typeof rejectUnauthorized === 'boolean') {
+    let returnValue = true;
+    if (typeof rejectUnauthorized === 'boolean') {
       returnValue = rejectUnauthorized;
     } else if (typeof rejectUnauthorized === 'number') {
       returnValue = rejectUnauthorized === 1;

--- a/src/classes/Agent.ts
+++ b/src/classes/Agent.ts
@@ -97,10 +97,10 @@ abstract class Agent {
     boolean returnValue = false;
 
     if (typeof rejectUnauthorized === boolean) {
-      returnValue = rejectUnauthorized
+      returnValue = rejectUnauthorized;
     } else if (typeof rejectUnauthorized === number) {
-      returnValue = rejectUnauthorized === 1
-    } else if (typeof rejectUnauthorized === string){
+      returnValue = rejectUnauthorized === 1;
+    } else if (typeof rejectUnauthorized === string) {
       returnValue = ['true', 't', 'yes', 'y', 'on', '1'].includes(rejectUnauthorized.trim().toLowerCase());
     }
 

--- a/src/classes/Agent.ts
+++ b/src/classes/Agent.ts
@@ -75,13 +75,13 @@ abstract class Agent {
    */
   public addCACertificates (ca: string | string[]) {
     if (!ca) {
-      log.error("Invalid input ca certificate");
+      log.error('Invalid input ca certificate');
     } else if (this.ca) {
       if (typeof ca === typeof this.ca) {
         // concat valid ca certificates with the existing certificates,
         this.ca = this.ca.concat(ca);
       } else {
-        log.error("Input ca certificate's type mismatched with existing ca certificate's type");
+        log.error('Input ca certificate type mismatched with existing ca certificate type');
       }
     } else {
       this.ca = ca;

--- a/src/classes/Agent.ts
+++ b/src/classes/Agent.ts
@@ -55,7 +55,7 @@ abstract class Agent {
   public socketConnectionTimeout: number;
   
   // ca property is an array of ca certificates
-  public ca: object;
+  public ca: Array<string>;
 
   public constructor (
     isProxyConfigured: IsProxyConfiguredMethodType,
@@ -63,21 +63,21 @@ abstract class Agent {
     getUrlProxy: GetUrlProxyMethodType,
     fallbackAgent: AgentType,
     socketConnectionTimeout: number,
-	  ca: object,
+    ca: Array<string>,
   ) {
     this.fallbackAgent = fallbackAgent;
     this.isProxyConfigured = isProxyConfigured;
     this.mustUrlUseProxy = mustUrlUseProxy;
     this.getUrlProxy = getUrlProxy;
     this.socketConnectionTimeout = socketConnectionTimeout;
-	  this.ca = ca || [];
+    this.ca = ca || [];
   }
   
   /**
    * This method can be used to add an array of ca certificates
    * @param {*} ca an array of ca certificates
    */
-  public addCACertificates (ca: object) {
+  public addCACertificates (ca: Array<string>) {
     // concat valid ca certificates with the existing certificates,
     if (ca) {
       this.ca = this.ca.concat(ca);

--- a/src/classes/Agent.ts
+++ b/src/classes/Agent.ts
@@ -94,7 +94,7 @@ abstract class Agent {
   public getRejectUnauthorized () {
     // eslint-disable-next-line node/no-process-env
     const rejectUnauthorized = process.env.NODE_TLS_REJECT_UNAUTHORIZED;    
-    boolean returnValue = false;
+    let returnValue = false;
 
     if (typeof rejectUnauthorized === boolean) {
       returnValue = rejectUnauthorized;

--- a/src/classes/Agent.ts
+++ b/src/classes/Agent.ts
@@ -93,7 +93,7 @@ abstract class Agent {
    */
   public getRejectUnauthorized () {
     // eslint-disable-next-line node/no-process-env
-    const rejectUnauthorized = process.env.NODE_TLS_REJECT_UNAUTHORIZED;    
+    const rejectUnauthorized = process.env.NODE_TLS_REJECT_UNAUTHORIZED;
     let returnValue = false;
     if (typeof rejectUnauthorized === 'undefined') {
       returnValue = true;

--- a/src/classes/Agent.ts
+++ b/src/classes/Agent.ts
@@ -75,13 +75,15 @@ abstract class Agent {
    */
   public addCACertificates (ca: string | string[]) {
     // concat valid ca certificates with the existing certificates,
-    if (ca) {
-      if(this.ca) {
+    if (this.ca) {
+      if (typeof ca === typeof this.ca) {
         this.ca = this.ca.concat(ca);
       } else {
-        this.ca = ca;
+        log.error("Input ca type mismatched with existing ca type");
       }
-    }
+    } else {
+      this.ca = ca;
+    }  
   }
 
   /**

--- a/src/classes/Agent.ts
+++ b/src/classes/Agent.ts
@@ -63,7 +63,7 @@ abstract class Agent {
     getUrlProxy: GetUrlProxyMethodType,
     fallbackAgent: AgentType,
     socketConnectionTimeout: number,
-    ca: Array<string>,
+    ca: string[],
   ) {
     this.fallbackAgent = fallbackAgent;
     this.isProxyConfigured = isProxyConfigured;
@@ -75,9 +75,9 @@ abstract class Agent {
   
   /**
    * This method can be used to add an array of ca certificates
-   * @param {*} ca an array of ca certificates
+   * @param {string[]} ca an array of ca certificates
    */
-  public addCACertificates (ca: Array<string>) {
+  public addCACertificates (ca: string[]) {
     // concat valid ca certificates with the existing certificates,
     if (ca) {
       this.ca = this.ca.concat(ca);

--- a/src/classes/Agent.ts
+++ b/src/classes/Agent.ts
@@ -63,14 +63,14 @@ abstract class Agent {
     getUrlProxy: GetUrlProxyMethodType,
     fallbackAgent: AgentType,
     socketConnectionTimeout: number,
-	ca: object,
+	  ca: object,
   ) {
     this.fallbackAgent = fallbackAgent;
     this.isProxyConfigured = isProxyConfigured;
     this.mustUrlUseProxy = mustUrlUseProxy;
     this.getUrlProxy = getUrlProxy;
     this.socketConnectionTimeout = socketConnectionTimeout;
-	this.ca = ca || [];
+	  this.ca = ca || [];
   }
   
   /**

--- a/src/classes/Agent.ts
+++ b/src/classes/Agent.ts
@@ -96,11 +96,11 @@ abstract class Agent {
     const rejectUnauthorized = process.env.NODE_TLS_REJECT_UNAUTHORIZED;    
     let returnValue = false;
 
-    if (typeof rejectUnauthorized === boolean) {
+    if (typeof rejectUnauthorized === "boolean") {
       returnValue = rejectUnauthorized;
-    } else if (typeof rejectUnauthorized === number) {
+    } else if (typeof rejectUnauthorized === "number") {
       returnValue = rejectUnauthorized === 1;
-    } else if (typeof rejectUnauthorized === string) {
+    } else if (typeof rejectUnauthorized === "string") {
       returnValue = ['true', 't', 'yes', 'y', 'on', '1'].includes(rejectUnauthorized.trim().toLowerCase());
     }
 

--- a/src/classes/HttpProxyAgent.ts
+++ b/src/classes/HttpProxyAgent.ts
@@ -17,7 +17,7 @@ class HttpProxyAgent extends Agent {
     getUrlProxy: GetUrlProxyMethodType,
     fallbackAgent: AgentType,
     socketConnectionTimeout: number,
-    ca: string | string[] | undefined,
+    ca: string[] | string | undefined,
   ) {
     super(
       isProxyConfigured,

--- a/src/classes/HttpProxyAgent.ts
+++ b/src/classes/HttpProxyAgent.ts
@@ -17,7 +17,7 @@ class HttpProxyAgent extends Agent {
     getUrlProxy: GetUrlProxyMethodType,
     fallbackAgent: AgentType,
     socketConnectionTimeout: number,
-    ca: string[],
+    ca: string | string[] | undefined,
   ) {
     super(
       isProxyConfigured,

--- a/src/classes/HttpProxyAgent.ts
+++ b/src/classes/HttpProxyAgent.ts
@@ -17,7 +17,7 @@ class HttpProxyAgent extends Agent {
     getUrlProxy: GetUrlProxyMethodType,
     fallbackAgent: AgentType,
     socketConnectionTimeout: number,
-    ca: Array<string>,
+    ca: string[],
   ) {
     super(
       isProxyConfigured,

--- a/src/classes/HttpProxyAgent.ts
+++ b/src/classes/HttpProxyAgent.ts
@@ -17,6 +17,7 @@ class HttpProxyAgent extends Agent {
     getUrlProxy: GetUrlProxyMethodType,
     fallbackAgent: AgentType,
     socketConnectionTimeout: number,
+    ca: Array<string>,
   ) {
     super(
       isProxyConfigured,
@@ -24,6 +25,7 @@ class HttpProxyAgent extends Agent {
       getUrlProxy,
       fallbackAgent,
       socketConnectionTimeout,
+      ca,
     );
 
     this.protocol = 'http:';

--- a/src/classes/HttpsProxyAgent.ts
+++ b/src/classes/HttpsProxyAgent.ts
@@ -17,6 +17,7 @@ class HttpsProxyAgent extends Agent {
     getUrlProxy: GetUrlProxyMethodType,
     fallbackAgent: AgentType,
     socketConnectionTimeout: number,
+    ca: Array<string>,
   ) {
     super(
       isProxyConfigured,
@@ -24,6 +25,7 @@ class HttpsProxyAgent extends Agent {
       getUrlProxy,
       fallbackAgent,
       socketConnectionTimeout,
+      ca,
     );
 
     this.protocol = 'https:';

--- a/src/classes/HttpsProxyAgent.ts
+++ b/src/classes/HttpsProxyAgent.ts
@@ -17,7 +17,7 @@ class HttpsProxyAgent extends Agent {
     getUrlProxy: GetUrlProxyMethodType,
     fallbackAgent: AgentType,
     socketConnectionTimeout: number,
-    ca: string[],
+    ca: string | string[] | undefined,
   ) {
     super(
       isProxyConfigured,

--- a/src/classes/HttpsProxyAgent.ts
+++ b/src/classes/HttpsProxyAgent.ts
@@ -17,7 +17,7 @@ class HttpsProxyAgent extends Agent {
     getUrlProxy: GetUrlProxyMethodType,
     fallbackAgent: AgentType,
     socketConnectionTimeout: number,
-    ca: Array<string>,
+    ca: string[],
   ) {
     super(
       isProxyConfigured,

--- a/src/classes/HttpsProxyAgent.ts
+++ b/src/classes/HttpsProxyAgent.ts
@@ -17,7 +17,7 @@ class HttpsProxyAgent extends Agent {
     getUrlProxy: GetUrlProxyMethodType,
     fallbackAgent: AgentType,
     socketConnectionTimeout: number,
-    ca: string | string[] | undefined,
+    ca: string[] | string | undefined,
   ) {
     super(
       isProxyConfigured,

--- a/src/factories/createGlobalProxyAgent.ts
+++ b/src/factories/createGlobalProxyAgent.ts
@@ -49,6 +49,7 @@ const createConfiguration = (configurationInput: ProxyAgentConfigurationInputTyp
     environmentVariableNamespace: typeof environment.GLOBAL_AGENT_ENVIRONMENT_VARIABLE_NAMESPACE === 'string' ? environment.GLOBAL_AGENT_ENVIRONMENT_VARIABLE_NAMESPACE : 'GLOBAL_AGENT_',
     forceGlobalAgent: typeof environment.GLOBAL_AGENT_FORCE_GLOBAL_AGENT === 'string' ? parseBoolean(environment.GLOBAL_AGENT_FORCE_GLOBAL_AGENT) : true,
     socketConnectionTimeout: typeof environment.GLOBAL_AGENT_SOCKET_CONNECTION_TIMEOUT === 'string' ? Number.parseInt(environment.GLOBAL_AGENT_SOCKET_CONNECTION_TIMEOUT, 10) : defaultConfigurationInput.socketConnectionTimeout,
+    ca: configurationInput.ca ? configuration.ca : [],
   };
 
   return {

--- a/src/factories/createGlobalProxyAgent.ts
+++ b/src/factories/createGlobalProxyAgent.ts
@@ -49,7 +49,7 @@ const createConfiguration = (configurationInput: ProxyAgentConfigurationInputTyp
     environmentVariableNamespace: typeof environment.GLOBAL_AGENT_ENVIRONMENT_VARIABLE_NAMESPACE === 'string' ? environment.GLOBAL_AGENT_ENVIRONMENT_VARIABLE_NAMESPACE : 'GLOBAL_AGENT_',
     forceGlobalAgent: typeof environment.GLOBAL_AGENT_FORCE_GLOBAL_AGENT === 'string' ? parseBoolean(environment.GLOBAL_AGENT_FORCE_GLOBAL_AGENT) : true,
     socketConnectionTimeout: typeof environment.GLOBAL_AGENT_SOCKET_CONNECTION_TIMEOUT === 'string' ? Number.parseInt(environment.GLOBAL_AGENT_SOCKET_CONNECTION_TIMEOUT, 10) : defaultConfigurationInput.socketConnectionTimeout,
-    ca: configurationInput.ca ? configuration.ca : [],
+    ca: configurationInput.ca ? configurationInput.ca : [],
   };
 
   return {

--- a/src/factories/createGlobalProxyAgent.ts
+++ b/src/factories/createGlobalProxyAgent.ts
@@ -46,7 +46,6 @@ const createConfiguration = (configurationInput: ProxyAgentConfigurationInputTyp
   const environment = process.env;
 
   const defaultConfiguration = {
-    ca: configurationInput.ca,
     environmentVariableNamespace: typeof environment.GLOBAL_AGENT_ENVIRONMENT_VARIABLE_NAMESPACE === 'string' ? environment.GLOBAL_AGENT_ENVIRONMENT_VARIABLE_NAMESPACE : 'GLOBAL_AGENT_',
     forceGlobalAgent: typeof environment.GLOBAL_AGENT_FORCE_GLOBAL_AGENT === 'string' ? parseBoolean(environment.GLOBAL_AGENT_FORCE_GLOBAL_AGENT) : true,
     socketConnectionTimeout: typeof environment.GLOBAL_AGENT_SOCKET_CONNECTION_TIMEOUT === 'string' ? Number.parseInt(environment.GLOBAL_AGENT_SOCKET_CONNECTION_TIMEOUT, 10) : defaultConfigurationInput.socketConnectionTimeout,

--- a/src/factories/createGlobalProxyAgent.ts
+++ b/src/factories/createGlobalProxyAgent.ts
@@ -46,10 +46,10 @@ const createConfiguration = (configurationInput: ProxyAgentConfigurationInputTyp
   const environment = process.env;
 
   const defaultConfiguration = {
+    ca: configurationInput.ca ? configurationInput.ca : [],
     environmentVariableNamespace: typeof environment.GLOBAL_AGENT_ENVIRONMENT_VARIABLE_NAMESPACE === 'string' ? environment.GLOBAL_AGENT_ENVIRONMENT_VARIABLE_NAMESPACE : 'GLOBAL_AGENT_',
     forceGlobalAgent: typeof environment.GLOBAL_AGENT_FORCE_GLOBAL_AGENT === 'string' ? parseBoolean(environment.GLOBAL_AGENT_FORCE_GLOBAL_AGENT) : true,
     socketConnectionTimeout: typeof environment.GLOBAL_AGENT_SOCKET_CONNECTION_TIMEOUT === 'string' ? Number.parseInt(environment.GLOBAL_AGENT_SOCKET_CONNECTION_TIMEOUT, 10) : defaultConfigurationInput.socketConnectionTimeout,
-    ca: configurationInput.ca ? configurationInput.ca : [],
   };
 
   return {

--- a/src/factories/createGlobalProxyAgent.ts
+++ b/src/factories/createGlobalProxyAgent.ts
@@ -46,7 +46,7 @@ const createConfiguration = (configurationInput: ProxyAgentConfigurationInputTyp
   const environment = process.env;
 
   const defaultConfiguration = {
-    ca: configurationInput.ca ? configurationInput.ca : [],
+    ca: configurationInput.ca,
     environmentVariableNamespace: typeof environment.GLOBAL_AGENT_ENVIRONMENT_VARIABLE_NAMESPACE === 'string' ? environment.GLOBAL_AGENT_ENVIRONMENT_VARIABLE_NAMESPACE : 'GLOBAL_AGENT_',
     forceGlobalAgent: typeof environment.GLOBAL_AGENT_FORCE_GLOBAL_AGENT === 'string' ? parseBoolean(environment.GLOBAL_AGENT_FORCE_GLOBAL_AGENT) : true,
     socketConnectionTimeout: typeof environment.GLOBAL_AGENT_SOCKET_CONNECTION_TIMEOUT === 'string' ? Number.parseInt(environment.GLOBAL_AGENT_SOCKET_CONNECTION_TIMEOUT, 10) : defaultConfigurationInput.socketConnectionTimeout,

--- a/src/factories/createGlobalProxyAgent.ts
+++ b/src/factories/createGlobalProxyAgent.ts
@@ -116,6 +116,7 @@ export default (configurationInput: ProxyAgentConfigurationInputType = defaultCo
         getUrlProxy(getHttpProxy),
         http.globalAgent,
         configuration.socketConnectionTimeout,
+        configuration.ca,
       );
     }
   };
@@ -136,6 +137,7 @@ export default (configurationInput: ProxyAgentConfigurationInputType = defaultCo
         getUrlProxy(getHttpsProxy),
         https.globalAgent,
         configuration.socketConnectionTimeout,
+        configuration.ca,
       );
     }
   };

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,7 +18,7 @@ export type ProxyConfigurationType = {
 };
 
 export type TlsConfigurationType = {
-  ca?: Array<string>,
+  ca?: string[],
   cert?: string,
   ciphers?: string,
   clientCertEngine?: string,
@@ -55,12 +55,12 @@ export type ProxyAgentConfigurationInputType = {
   environmentVariableNamespace?: string,
   forceGlobalAgent?: boolean,
   socketConnectionTimeout?: number,
-  ca?: Array<string>,
+  ca?: string[],
 };
 
 export type ProxyAgentConfigurationType = {
   environmentVariableNamespace: string,
   forceGlobalAgent: boolean,
   socketConnectionTimeout: number,
-  ca?: Array<string>,
+  ca?: string[],
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,7 +18,7 @@ export type ProxyConfigurationType = {
 };
 
 export type TlsConfigurationType = {
-  ca?: string | string[] | undefined,
+  ca?: string | string[],
   cert?: string,
   ciphers?: string,
   clientCertEngine?: string,
@@ -55,12 +55,12 @@ export type ProxyAgentConfigurationInputType = {
   environmentVariableNamespace?: string,
   forceGlobalAgent?: boolean,
   socketConnectionTimeout?: number,
-  ca?: string | string[] | undefined,
+  ca?: string | string[],
 };
 
 export type ProxyAgentConfigurationType = {
   environmentVariableNamespace: string,
   forceGlobalAgent: boolean,
   socketConnectionTimeout: number,
-  ca: string | string[] | undefined,
+  ca?: string | string[],
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -62,5 +62,5 @@ export type ProxyAgentConfigurationType = {
   environmentVariableNamespace: string,
   forceGlobalAgent: boolean,
   socketConnectionTimeout: number,
-  ca?: string[],
+  ca: string[],
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,7 +18,7 @@ export type ProxyConfigurationType = {
 };
 
 export type TlsConfigurationType = {
-  ca?: string[],
+  ca?: string | string[] | undefined,
   cert?: string,
   ciphers?: string,
   clientCertEngine?: string,
@@ -55,12 +55,12 @@ export type ProxyAgentConfigurationInputType = {
   environmentVariableNamespace?: string,
   forceGlobalAgent?: boolean,
   socketConnectionTimeout?: number,
-  ca?: string[],
+  ca?: string | string[] | undefined,
 };
 
 export type ProxyAgentConfigurationType = {
   environmentVariableNamespace: string,
   forceGlobalAgent: boolean,
   socketConnectionTimeout: number,
-  ca: string[],
+  ca: string | string[] | undefined,
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,7 +18,7 @@ export type ProxyConfigurationType = {
 };
 
 export type TlsConfigurationType = {
-  ca?: string | string[],
+  ca?: string[] | string,
   cert?: string,
   ciphers?: string,
   clientCertEngine?: string,
@@ -55,12 +55,12 @@ export type ProxyAgentConfigurationInputType = {
   environmentVariableNamespace?: string,
   forceGlobalAgent?: boolean,
   socketConnectionTimeout?: number,
-  ca?: string | string[],
+  ca?: string[] | string,
 };
 
 export type ProxyAgentConfigurationType = {
   environmentVariableNamespace: string,
   forceGlobalAgent: boolean,
   socketConnectionTimeout: number,
-  ca?: string | string[],
+  ca?: string[] | string,
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,7 +18,7 @@ export type ProxyConfigurationType = {
 };
 
 export type TlsConfigurationType = {
-  ca?: string,
+  ca?: object,
   cert?: string,
   ciphers?: string,
   clientCertEngine?: string,
@@ -55,10 +55,12 @@ export type ProxyAgentConfigurationInputType = {
   environmentVariableNamespace?: string,
   forceGlobalAgent?: boolean,
   socketConnectionTimeout?: number,
+  ca?: object,
 };
 
 export type ProxyAgentConfigurationType = {
   environmentVariableNamespace: string,
   forceGlobalAgent: boolean,
   socketConnectionTimeout: number,
+  ca: object,
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,7 +18,7 @@ export type ProxyConfigurationType = {
 };
 
 export type TlsConfigurationType = {
-  ca?: object,
+  ca?: Array<string>,
   cert?: string,
   ciphers?: string,
   clientCertEngine?: string,
@@ -55,12 +55,12 @@ export type ProxyAgentConfigurationInputType = {
   environmentVariableNamespace?: string,
   forceGlobalAgent?: boolean,
   socketConnectionTimeout?: number,
-  ca?: object,
+  ca?: Array<string>,
 };
 
 export type ProxyAgentConfigurationType = {
   environmentVariableNamespace: string,
   forceGlobalAgent: boolean,
   socketConnectionTimeout: number,
-  ca: object,
+  ca?: Array<string>,
 };

--- a/test/global-agent/factories/createGlobalProxyAgent.ts
+++ b/test/global-agent/factories/createGlobalProxyAgent.ts
@@ -53,6 +53,9 @@ const anyproxyDefaultRules = {
 const defaultHttpAgent = http.globalAgent;
 const defaultHttpsAgent = https.globalAgent;
 
+// eslint-disable-next-line node/no-process-env
+const defaultNodeTlsRejectUnauthorized = process.env.NODE_TLS_REJECT_UNAUTHORIZED;
+
 let lastPort = 3_000;
 
 let localProxyServers: ProxyServerType[] = [];
@@ -95,6 +98,9 @@ afterEach(() => {
   }
 
   localHttpServers = [];
+  //reset NODE_TLS_REJECT_UNAUTHORIZED to original value
+  // eslint-disable-next-line node/no-process-env
+  process.env.NODE_TLS_REJECT_UNAUTHORIZED = defaultNodeTlsRejectUnauthorized;
 });
 
 type HttpResponseType = {
@@ -195,90 +201,6 @@ serial('proxies HTTP request', async (t) => {
   t.is(response.body, 'OK');
 });
 
-serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = undefined', async (t) => {
-  // eslint-disable-next-line node/no-process-env
-  process.env = {};
-  const globalProxyAgent = createGlobalProxyAgent();
-  const proxyServer = await createProxyServer();
-  globalProxyAgent.HTTP_PROXY = proxyServer.url;
-
-  t.is((https.globalAgent as any).getRejectUnauthorized(), true);
-});
-
-serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = null', async (t) => {
-  // eslint-disable-next-line node/no-process-env
-  process.env.NODE_TLS_REJECT_UNAUTHORIZED = 'null';
-  const globalProxyAgent = createGlobalProxyAgent();
-  const proxyServer = await createProxyServer();
-  globalProxyAgent.HTTP_PROXY = proxyServer.url;
-
-  t.is((https.globalAgent as any).getRejectUnauthorized(), false);
-});
-
-serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = 1', async (t) => {
-  // eslint-disable-next-line node/no-process-env
-  process.env.NODE_TLS_REJECT_UNAUTHORIZED = '1';
-  const globalProxyAgent = createGlobalProxyAgent();
-
-  const proxyServer = await createProxyServer();
-
-  globalProxyAgent.HTTP_PROXY = proxyServer.url;
-
-  t.is((https.globalAgent as any).getRejectUnauthorized(), true);
-});
-
-serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = 0', async (t) => {
-  // eslint-disable-next-line node/no-process-env
-  process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
-  const globalProxyAgent = createGlobalProxyAgent();
-
-  const proxyServer = await createProxyServer();
-
-  globalProxyAgent.HTTP_PROXY = proxyServer.url;
-
-  t.is((https.globalAgent as any).getRejectUnauthorized(), false);
-});
-
-serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = true', async (t) => {
-  // eslint-disable-next-line node/no-process-env
-  process.env.NODE_TLS_REJECT_UNAUTHORIZED = 'true';
-  const globalProxyAgent = createGlobalProxyAgent();
-  const proxyServer = await createProxyServer();
-  globalProxyAgent.HTTP_PROXY = proxyServer.url;
-
-  t.is((https.globalAgent as any).getRejectUnauthorized(), true);
-});
-
-serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = false', async (t) => {
-  // eslint-disable-next-line node/no-process-env
-  process.env.NODE_TLS_REJECT_UNAUTHORIZED = 'false';
-  const globalProxyAgent = createGlobalProxyAgent();
-  const proxyServer = await createProxyServer();
-  globalProxyAgent.HTTP_PROXY = proxyServer.url;
-
-  t.is((https.globalAgent as any).getRejectUnauthorized(), false);
-});
-
-serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = yes', async (t) => {
-  // eslint-disable-next-line node/no-process-env
-  process.env.NODE_TLS_REJECT_UNAUTHORIZED = 'yes';
-  const globalProxyAgent = createGlobalProxyAgent();
-  const proxyServer = await createProxyServer();
-  globalProxyAgent.HTTP_PROXY = proxyServer.url;
-
-  t.is((https.globalAgent as any).getRejectUnauthorized(), true);
-});
-
-serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = no', async (t) => {
-  // eslint-disable-next-line node/no-process-env
-  process.env.NODE_TLS_REJECT_UNAUTHORIZED = 'no';
-  const globalProxyAgent = createGlobalProxyAgent();
-  const proxyServer = await createProxyServer();
-  globalProxyAgent.HTTP_PROXY = proxyServer.url;
-
-  t.is((https.globalAgent as any).getRejectUnauthorized(), false);
-});
-
 serial('proxies HTTP request with proxy-authorization header', async (t) => {
   const globalProxyAgent = createGlobalProxyAgent();
 
@@ -299,18 +221,95 @@ serial('proxies HTTP request with proxy-authorization header', async (t) => {
   t.is(beforeSendRequest.firstCall.args[0].requestOptions.headers['proxy-authorization'], 'Basic Zm9v');
 });
 
-serial('proxies HTTPS request', async (t) => {
+serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = undefined', async (t) => {
+  // eslint-disable-next-line node/no-process-env
+  process.env = {};
+  const globalProxyAgent = createGlobalProxyAgent();
+  const proxyServer = await createProxyServer();
+  globalProxyAgent.HTTP_PROXY = proxyServer.url;
+  const globalAgent : any = https.globalAgent;
+  t.is(globalAgent.getRejectUnauthorized(), true);
+});
+
+serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = null', async (t) => {
+  // eslint-disable-next-line node/no-process-env
+  process.env.NODE_TLS_REJECT_UNAUTHORIZED = 'null';
+  const globalProxyAgent = createGlobalProxyAgent();
+  const proxyServer = await createProxyServer();
+  globalProxyAgent.HTTP_PROXY = proxyServer.url;
+
+  const globalAgent : any = https.globalAgent;
+  t.is(globalAgent.getRejectUnauthorized(), false);
+});
+
+serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = 1', async (t) => {
+  // eslint-disable-next-line node/no-process-env
+  process.env.NODE_TLS_REJECT_UNAUTHORIZED = '1';
   const globalProxyAgent = createGlobalProxyAgent();
 
   const proxyServer = await createProxyServer();
 
   globalProxyAgent.HTTP_PROXY = proxyServer.url;
 
-  const response: HttpResponseType = await new Promise((resolve) => {
-    https.get('https://127.0.0.1', {}, createHttpResponseResolver(resolve));
-  });
+  const globalAgent : any = https.globalAgent;
+  t.is(globalAgent.getRejectUnauthorized(), true);
+});
 
-  t.is(response.body, 'OK');
+serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = 0', async (t) => {
+  // eslint-disable-next-line node/no-process-env
+  process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+  const globalProxyAgent = createGlobalProxyAgent();
+
+  const proxyServer = await createProxyServer();
+
+  globalProxyAgent.HTTP_PROXY = proxyServer.url;
+
+  const globalAgent : any = https.globalAgent;
+  t.is(globalAgent.getRejectUnauthorized(), false);
+});
+
+serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = true', async (t) => {
+  // eslint-disable-next-line node/no-process-env
+  process.env.NODE_TLS_REJECT_UNAUTHORIZED = 'true';
+  const globalProxyAgent = createGlobalProxyAgent();
+  const proxyServer = await createProxyServer();
+  globalProxyAgent.HTTP_PROXY = proxyServer.url;
+
+  const globalAgent : any = https.globalAgent;
+  t.is(globalAgent.getRejectUnauthorized(), true);
+});
+
+serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = false', async (t) => {
+  // eslint-disable-next-line node/no-process-env
+  process.env.NODE_TLS_REJECT_UNAUTHORIZED = 'false';
+  const globalProxyAgent = createGlobalProxyAgent();
+  const proxyServer = await createProxyServer();
+  globalProxyAgent.HTTP_PROXY = proxyServer.url;
+
+  const globalAgent : any = https.globalAgent;
+  t.is(globalAgent.getRejectUnauthorized(), false);
+});
+
+serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = yes', async (t) => {
+  // eslint-disable-next-line node/no-process-env
+  process.env.NODE_TLS_REJECT_UNAUTHORIZED = 'yes';
+  const globalProxyAgent = createGlobalProxyAgent();
+  const proxyServer = await createProxyServer();
+  globalProxyAgent.HTTP_PROXY = proxyServer.url;
+
+  const globalAgent : any = https.globalAgent;
+  t.is(globalAgent.getRejectUnauthorized(), true);
+});
+
+serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = no', async (t) => {
+  // eslint-disable-next-line node/no-process-env
+  process.env.NODE_TLS_REJECT_UNAUTHORIZED = 'no';
+  const globalProxyAgent = createGlobalProxyAgent();
+  const proxyServer = await createProxyServer();
+  globalProxyAgent.HTTP_PROXY = proxyServer.url;
+
+  const globalAgent : any = https.globalAgent;
+  t.is(globalAgent.getRejectUnauthorized(), false);
 });
 
 serial('Test addCACertificates and clearCACertificates methods', async (t) => {
@@ -326,11 +325,6 @@ serial('Test addCACertificates and clearCACertificates methods', async (t) => {
   const result = ['test-ca-certficate1', 'test-ca-certficate2', 'test-ca-certficate3'];
   t.is(globalAgent.ca.length, result.length);
   t.is(JSON.stringify(globalAgent.ca), JSON.stringify(result));
-  const response: HttpResponseType = await new Promise((resolve) => {
-    https.get('https://127.0.0.1', {}, createHttpResponseResolver(resolve));
-  });
-
-  t.is(response.body, 'OK');
   globalAgent.clearCACertificates();
   t.is(globalAgent.ca.length, 0);
 });
@@ -347,7 +341,7 @@ serial('Test addCACertificates when passed ca array is null or undefined', async
   globalAgent.addCACertificates(null);
   t.is(globalAgent.ca.length, 0);
   const response: HttpResponseType = await new Promise((resolve) => {
-    https.get('https://127.0.0.1', {}, createHttpResponseResolver(resolve));
+    https.get('https://127.0.0.1', {secureEndpoint: true}, createHttpResponseResolver(resolve));
   });
   t.is(response.body, 'OK');
 });
@@ -362,8 +356,22 @@ serial('Test initializing ca certificate property while creating global proxy ag
   t.is(globalAgent.ca.length, 1);
   t.is(globalAgent.ca[0], 'test-ca');
   const response: HttpResponseType = await new Promise((resolve) => {
+    https.get('https://127.0.0.1', {secureEndpoint: true}, createHttpResponseResolver(resolve));
+  });
+  t.is(response.body, 'OK');
+});
+
+serial('proxies HTTPS request', async (t) => {
+  const globalProxyAgent = createGlobalProxyAgent();
+
+  const proxyServer = await createProxyServer();
+
+  globalProxyAgent.HTTP_PROXY = proxyServer.url;
+
+  const response: HttpResponseType = await new Promise((resolve) => {
     https.get('https://127.0.0.1', {}, createHttpResponseResolver(resolve));
   });
+
   t.is(response.body, 'OK');
 });
 

--- a/test/global-agent/factories/createGlobalProxyAgent.ts
+++ b/test/global-agent/factories/createGlobalProxyAgent.ts
@@ -245,8 +245,9 @@ serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = nu
 });
 
 serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = 1', async (t) => {
+  // @ts-expect-error it is expected as we wanted to set process variable with int
   // eslint-disable-next-line node/no-process-env
-  process.env.NODE_TLS_REJECT_UNAUTHORIZED = '1';
+  process.env.NODE_TLS_REJECT_UNAUTHORIZED = 1;
   const globalProxyAgent = createGlobalProxyAgent();
 
   const proxyServer = await createProxyServer();
@@ -258,8 +259,9 @@ serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = 1'
 });
 
 serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = 0', async (t) => {
+  // @ts-expect-error it is expected as we wanted to set process variable with int
   // eslint-disable-next-line node/no-process-env
-  process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+  process.env.NODE_TLS_REJECT_UNAUTHORIZED = 0;
   const globalProxyAgent = createGlobalProxyAgent();
 
   const proxyServer = await createProxyServer();
@@ -271,8 +273,9 @@ serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = 0'
 });
 
 serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = true', async (t) => {
+  // @ts-expect-error it is expected as we wanted to set process variable with boolean
   // eslint-disable-next-line node/no-process-env
-  process.env.NODE_TLS_REJECT_UNAUTHORIZED = 'true';
+  process.env.NODE_TLS_REJECT_UNAUTHORIZED = true;
   const globalProxyAgent = createGlobalProxyAgent();
   const proxyServer = await createProxyServer();
   globalProxyAgent.HTTP_PROXY = proxyServer.url;
@@ -282,8 +285,9 @@ serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = tr
 });
 
 serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = false', async (t) => {
+  // @ts-expect-error it is expected as we wanted to set process variable with boolean
   // eslint-disable-next-line node/no-process-env
-  process.env.NODE_TLS_REJECT_UNAUTHORIZED = 'false';
+  process.env.NODE_TLS_REJECT_UNAUTHORIZED = false;
   const globalProxyAgent = createGlobalProxyAgent();
   const proxyServer = await createProxyServer();
   globalProxyAgent.HTTP_PROXY = proxyServer.url;
@@ -344,7 +348,7 @@ serial('Test addCACertificates when passed ca array is null or undefined', async
   t.is(globalAgent.ca.length, 0);
   const response: HttpResponseType = await new Promise((resolve) => {
     // @ts-expect-error seems 'secureEndpoint' property is not supported by RequestOptions but it should be.
-    https.get('https://127.0.0.1', {ca: ['test-ca'], secureEndpoint: true}, createHttpResponseResolver(resolve));
+    https.get('https://127.0.0.1', {ca: ['test-ca'], secureEndpoint: true, servername: '127.0.0.1'}, createHttpResponseResolver(resolve));
   });
   t.is(response.body, 'OK');
 });
@@ -360,7 +364,7 @@ serial('Test initializing ca certificate property while creating global proxy ag
   t.is(globalAgent.ca[0], 'test-ca');
   const response: HttpResponseType = await new Promise((resolve) => {
     // @ts-expect-error seems 'secureEndpoint' property is not supported by RequestOptions but it should be.
-    https.get('https://127.0.0.1', {secureEndpoint: true, rejectUnauthorized: false}, createHttpResponseResolver(resolve));
+    https.get('https://127.0.0.1', {rejectUnauthorized: false, secureEndpoint: true}, createHttpResponseResolver(resolve));
   });
   t.is(response.body, 'OK');
 });

--- a/test/global-agent/factories/createGlobalProxyAgent.ts
+++ b/test/global-agent/factories/createGlobalProxyAgent.ts
@@ -344,7 +344,7 @@ serial('Test addCACertificates when passed ca array is null or undefined', async
   t.is(globalAgent.ca.length, 0);
   const response: HttpResponseType = await new Promise((resolve) => {
     // @ts-expect-error seems 'secureEndpoint' property is not supported by RequestOptions but it should be.
-    https.get('https://127.0.0.1', {ca: ['test-ca'], secureEndpoint: true, rejectUnauthorized: false}, createHttpResponseResolver(resolve));
+    https.get('https://127.0.0.1', {ca: ['test-ca'], secureEndpoint: true}, createHttpResponseResolver(resolve));
   });
   t.is(response.body, 'OK');
 });

--- a/test/global-agent/factories/createGlobalProxyAgent.ts
+++ b/test/global-agent/factories/createGlobalProxyAgent.ts
@@ -201,19 +201,20 @@ serial('Test addCACertificates and clearCACertificates methods', async (t) => {
   const proxyServer = await createProxyServer();
 
   globalProxyAgent.HTTP_PROXY = proxyServer.url;
-  t.is(https.globalAgent.ca.length, 0);
-  https.globalAgent.addCACertificates(['test-ca-certficate1', 'test-ca-certficate2']);
-  https.globalAgent.addCACertificates(['test-ca-certficate3']);
+  const globalAgent: any = https.globalAgent;
+  t.is(globalAgent.ca.length, 0);
+  globalAgent.addCACertificates(['test-ca-certficate1', 'test-ca-certficate2']);
+  globalAgent.addCACertificates(['test-ca-certficate3']);
   const result = ['test-ca-certficate1', 'test-ca-certficate2', 'test-ca-certficate3'];
-  t.is(https.globalAgent.ca.length, result.length);
-  t.is(JSON.stringify(https.globalAgent.ca), JSON.stringify(result));
+  t.is(globalAgent.ca.length, result.length);
+  t.is(JSON.stringify(globalAgent.ca), JSON.stringify(result));
   const response = await new Promise((resolve) => {
     https.get('https://127.0.0.1', {}, createHttpResponseResolver(resolve));
   });
 
   t.is(response.body, 'OK');
-  https.globalAgent.clearCACertificates();
-  t.is(https.globalAgent.ca.length, 0);
+  globalAgent.clearCACertificates();
+  t.is(globalAgent.ca.length, 0);
 });
 
 serial('Test addCACertificates when passed ca array is null or undefined', async (t) => {
@@ -222,10 +223,11 @@ serial('Test addCACertificates when passed ca array is null or undefined', async
   const proxyServer = await createProxyServer();
 
   globalProxyAgent.HTTP_PROXY = proxyServer.url;
-  t.is(https.globalAgent.ca.length, 0);
-  https.globalAgent.addCACertificates(undefined);
-  https.globalAgent.addCACertificates(null);
-  t.is(https.globalAgent.ca.length, 0);
+  const globalAgent: any = https.globalAgent;
+  t.is(globalAgent.ca.length, 0);
+  globalAgent.addCACertificates(undefined);
+  globalAgent.addCACertificates(null);
+  t.is(globalAgent.ca.length, 0);
   const response = await new Promise((resolve) => {
     https.get('https://127.0.0.1', {}, createHttpResponseResolver(resolve));
   });
@@ -238,9 +240,9 @@ serial('Test initializing ca certificate property while creating global proxy ag
   const proxyServer = await createProxyServer();
 
   globalProxyAgent.HTTP_PROXY = proxyServer.url;
-
-  t.is(https.globalAgent.ca.length, 1);
-  t.is(https.globalAgent.ca[0], 'test-ca');
+  const globalAgent: any = https.globalAgent;
+  t.is(globalAgent.ca.length, 1);
+  t.is(globalAgent.ca[0], 'test-ca');
   const response = await new Promise((resolve) => {
     https.get('https://127.0.0.1', {}, createHttpResponseResolver(resolve));
   });
@@ -254,7 +256,7 @@ serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = un
   const proxyServer = await createProxyServer();
   globalProxyAgent.HTTP_PROXY = proxyServer.url;
 
-  t.is(https.globalAgent.getRejectUnauthorized(), true);
+  t.is((https.globalAgent as any).getRejectUnauthorized(), true);
 });
 
 serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = null', async (t) => {
@@ -264,51 +266,51 @@ serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = nu
   const proxyServer = await createProxyServer();
   globalProxyAgent.HTTP_PROXY = proxyServer.url;
 
-  t.is(https.globalAgent.getRejectUnauthorized(), false);
+  t.is((https.globalAgent as any).getRejectUnauthorized(), false);
 });
 
 serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = 1', async (t) => {
   // eslint-disable-next-line node/no-process-env
-  process.env.NODE_TLS_REJECT_UNAUTHORIZED = 1;
+  process.env.NODE_TLS_REJECT_UNAUTHORIZED = '1';
   const globalProxyAgent = createGlobalProxyAgent();
 
   const proxyServer = await createProxyServer();
 
   globalProxyAgent.HTTP_PROXY = proxyServer.url;
 
-  t.is(https.globalAgent.getRejectUnauthorized(), true);
+  t.is((https.globalAgent as any).getRejectUnauthorized(), true);
 });
 
 serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = 0', async (t) => {
   // eslint-disable-next-line node/no-process-env
-  process.env.NODE_TLS_REJECT_UNAUTHORIZED = 0;
+  process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
   const globalProxyAgent = createGlobalProxyAgent();
 
   const proxyServer = await createProxyServer();
 
   globalProxyAgent.HTTP_PROXY = proxyServer.url;
 
-  t.is(https.globalAgent.getRejectUnauthorized(), false);
+  t.is((https.globalAgent as any).getRejectUnauthorized(), false);
 });
 
 serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = true', async (t) => {
   // eslint-disable-next-line node/no-process-env
-  process.env.NODE_TLS_REJECT_UNAUTHORIZED = true;
+  process.env.NODE_TLS_REJECT_UNAUTHORIZED = 'true';
   const globalProxyAgent = createGlobalProxyAgent();
   const proxyServer = await createProxyServer();
   globalProxyAgent.HTTP_PROXY = proxyServer.url;
 
-  t.is(https.globalAgent.getRejectUnauthorized(), true);
+  t.is((https.globalAgent as any).getRejectUnauthorized(), true);
 });
 
 serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = false', async (t) => {
   // eslint-disable-next-line node/no-process-env
-  process.env.NODE_TLS_REJECT_UNAUTHORIZED = false;
+  process.env.NODE_TLS_REJECT_UNAUTHORIZED = 'false';
   const globalProxyAgent = createGlobalProxyAgent();
   const proxyServer = await createProxyServer();
   globalProxyAgent.HTTP_PROXY = proxyServer.url;
 
-  t.is(https.globalAgent.getRejectUnauthorized(), false);
+  t.is((https.globalAgent as any).getRejectUnauthorized(), false);
 });
 
 serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = yes', async (t) => {
@@ -318,7 +320,7 @@ serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = ye
   const proxyServer = await createProxyServer();
   globalProxyAgent.HTTP_PROXY = proxyServer.url;
 
-  t.is(https.globalAgent.getRejectUnauthorized(), true);
+  t.is((https.globalAgent as any).getRejectUnauthorized(), true);
 });
 
 serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = no', async (t) => {
@@ -328,7 +330,7 @@ serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = no
   const proxyServer = await createProxyServer();
   globalProxyAgent.HTTP_PROXY = proxyServer.url;
 
-  t.is(https.globalAgent.getRejectUnauthorized(), false);
+  t.is((https.globalAgent as any).getRejectUnauthorized(), false);
 });
 
 serial('proxies HTTP request with proxy-authorization header', async (t) => {

--- a/test/global-agent/factories/createGlobalProxyAgent.ts
+++ b/test/global-agent/factories/createGlobalProxyAgent.ts
@@ -342,7 +342,25 @@ serial('Test addCACertificates and clearCACertificates methods', async (t) => {
   t.is(globalAgent.ca.length, result.length);
   t.is(JSON.stringify(globalAgent.ca), JSON.stringify(result));
   globalAgent.clearCACertificates();
-  t.is(globalAgent.ca.length, 0);
+  t.is(globalAgent.ca, undefined);
+});
+
+serial('Test addCACertificates when passed ca is a string', async (t) => {
+  const globalProxyAgent = createGlobalProxyAgent();
+
+  const proxyServer = await createProxyServer();
+
+  globalProxyAgent.HTTP_PROXY = proxyServer.url;
+  const globalAgent: any = https.globalAgent;
+  t.is(globalAgent.ca, undefined);
+  globalAgent.addCACertificates('test-ca-certficate1');
+  globalAgent.addCACertificates('test-ca-certficate2');
+  t.is(globalAgent.ca, 'test-ca-certficate1test-ca-certficate2');
+  const response: HttpResponseType = await new Promise((resolve) => {
+    // @ts-expect-error seems 'secureEndpoint' property is not supported by RequestOptions but it should be.
+    https.get('https://127.0.0.1', {ca: ['test-ca'], secureEndpoint: true, servername: '127.0.0.1'}, createHttpResponseResolver(resolve));
+  });
+  t.is(response.body, 'OK');
 });
 
 serial('Test addCACertificates when passed ca array is null or undefined', async (t) => {
@@ -352,10 +370,10 @@ serial('Test addCACertificates when passed ca array is null or undefined', async
 
   globalProxyAgent.HTTP_PROXY = proxyServer.url;
   const globalAgent: any = https.globalAgent;
-  t.is(globalAgent.ca.length, 0);
+  t.is(globalAgent.ca, undefined);
   globalAgent.addCACertificates(undefined);
   globalAgent.addCACertificates(null);
-  t.is(globalAgent.ca.length, 0);
+  t.is(globalAgent.ca, undefined);
   const response: HttpResponseType = await new Promise((resolve) => {
     // @ts-expect-error seems 'secureEndpoint' property is not supported by RequestOptions but it should be.
     https.get('https://127.0.0.1', {ca: ['test-ca'], secureEndpoint: true, servername: '127.0.0.1'}, createHttpResponseResolver(resolve));

--- a/test/global-agent/factories/createGlobalProxyAgent.ts
+++ b/test/global-agent/factories/createGlobalProxyAgent.ts
@@ -201,19 +201,19 @@ serial('Test addCACertificates and clearCACertificates methods', async (t) => {
   const proxyServer = await createProxyServer();
 
   globalProxyAgent.HTTP_PROXY = proxyServer.url;
-  t.is(https.globalAgent.ca.length === 0);
+  t.is(https.globalAgent.ca.length, 0);
   https.globalAgent.addCACertificates(['test-ca-certficate1', 'test-ca-certficate2']);
   https.globalAgent.addCACertificates(['test-ca-certficate3']);
   const result = ['test-ca-certficate1', 'test-ca-certficate2', 'test-ca-certficate3'];
-  t.is(https.globalAgent.ca.length === result.length);
-  t.is(JSON.stringify(https.globalAgent.ca) === JSON.stringify(result));
+  t.is(https.globalAgent.ca.length, result.length);
+  t.is(JSON.stringify(https.globalAgent.ca), JSON.stringify(result));
   const response = await new Promise((resolve) => {
     https.get('https://127.0.0.1', {}, createHttpResponseResolver(resolve));
   });
 
-  t.is(response.body === 'OK');
+  t.is(response.body, 'OK');
   https.globalAgent.clearCACertificates();
-  t.is(https.globalAgent.ca.length === 0);
+  t.is(https.globalAgent.ca.length, 0);
 });
 
 serial('Test addCACertificates when passed ca array is null or undefined', async (t) => {
@@ -222,14 +222,14 @@ serial('Test addCACertificates when passed ca array is null or undefined', async
   const proxyServer = await createProxyServer();
 
   globalProxyAgent.HTTP_PROXY = proxyServer.url;
-  t.is(https.globalAgent.ca.length === 0);
+  t.is(https.globalAgent.ca.length, 0);
   https.globalAgent.addCACertificates(undefined);
   https.globalAgent.addCACertificates(null);
-  t.is(https.globalAgent.ca.length === 0);
+  t.is(https.globalAgent.ca.length, 0);
   const response = await new Promise((resolve) => {
     https.get('https://127.0.0.1', {}, createHttpResponseResolver(resolve));
   });
-  t.is(response.body === 'OK');
+  t.is(response.body, 'OK');
 });
 
 serial('Test initializing ca certificate property while creating global proxy agent', async (t) => {
@@ -239,12 +239,12 @@ serial('Test initializing ca certificate property while creating global proxy ag
 
   globalProxyAgent.HTTP_PROXY = proxyServer.url;
 
-  t.is(https.globalAgent.ca.length === 1);
-  t.is(https.globalAgent.ca[0] === 'test-ca');
+  t.is(https.globalAgent.ca.length, 1);
+  t.is(https.globalAgent.ca[0], 'test-ca');
   const response = await new Promise((resolve) => {
     https.get('https://127.0.0.1', {}, createHttpResponseResolver(resolve));
   });
-  t.is(response.body === 'OK');
+  t.is(response.body, 'OK');
 });
 
 serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = undefined', async (t) => {
@@ -253,7 +253,7 @@ serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = un
   const proxyServer = await createProxyServer();
   globalProxyAgent.HTTP_PROXY = proxyServer.url;
 
-  t.is(https.globalAgent.getRejectUnauthorized() === true);
+  t.is(https.globalAgent.getRejectUnauthorized(), true);
 });
 
 serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = null', async (t) => {
@@ -262,7 +262,7 @@ serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = nu
   const proxyServer = await createProxyServer();
   globalProxyAgent.HTTP_PROXY = proxyServer.url;
 
-  t.is(https.globalAgent.getRejectUnauthorized() === false);
+  t.is(https.globalAgent.getRejectUnauthorized(), false);
 });
 
 serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = 1', async (t) => {
@@ -273,7 +273,7 @@ serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = 1'
 
   globalProxyAgent.HTTP_PROXY = proxyServer.url;
 
-  t.is(https.globalAgent.getRejectUnauthorized() === true);
+  t.is(https.globalAgent.getRejectUnauthorized(), true);
 });
 
 serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = 0', async (t) => {
@@ -284,7 +284,7 @@ serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = 0'
 
   globalProxyAgent.HTTP_PROXY = proxyServer.url;
 
-  t.is(https.globalAgent.getRejectUnauthorized() === false);
+  t.is(https.globalAgent.getRejectUnauthorized(), false);
 });
 
 serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = true', async (t) => {
@@ -293,7 +293,7 @@ serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = tr
   const proxyServer = await createProxyServer();
   globalProxyAgent.HTTP_PROXY = proxyServer.url;
 
-  t.is(https.globalAgent.getRejectUnauthorized() === true);
+  t.is(https.globalAgent.getRejectUnauthorized(), true);
 });
 
 serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = false', async (t) => {
@@ -302,7 +302,7 @@ serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = fa
   const proxyServer = await createProxyServer();
   globalProxyAgent.HTTP_PROXY = proxyServer.url;
 
-  t.is(https.globalAgent.getRejectUnauthorized() === false);
+  t.is(https.globalAgent.getRejectUnauthorized(), false);
 });
 
 serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = yes', async (t) => {
@@ -311,7 +311,7 @@ serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = ye
   const proxyServer = await createProxyServer();
   globalProxyAgent.HTTP_PROXY = proxyServer.url;
 
-  t.is(https.globalAgent.getRejectUnauthorized() === true);
+  t.is(https.globalAgent.getRejectUnauthorized(), true);
 });
 
 serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = no', async (t) => {
@@ -320,7 +320,7 @@ serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = no
   const proxyServer = await createProxyServer();
   globalProxyAgent.HTTP_PROXY = proxyServer.url;
 
-  t.is(https.globalAgent.getRejectUnauthorized() === false);
+  t.is(https.globalAgent.getRejectUnauthorized(), false);
 });
 
 serial('proxies HTTP request with proxy-authorization header', async (t) => {

--- a/test/global-agent/factories/createGlobalProxyAgent.ts
+++ b/test/global-agent/factories/createGlobalProxyAgent.ts
@@ -195,6 +195,134 @@ serial('proxies HTTP request', async (t) => {
   t.is(response.body, 'OK');
 });
 
+serial('Test addCACertificates and clearCACertificates methods', async (t) => {
+  const globalProxyAgent = createGlobalProxyAgent();
+
+  const proxyServer = await createProxyServer();
+
+  globalProxyAgent.HTTP_PROXY = proxyServer.url;
+  t.is(https.globalAgent.ca.length === 0);
+  https.globalAgent.addCACertificates(['test-ca-certficate1', 'test-ca-certficate2']);
+  https.globalAgent.addCACertificates(['test-ca-certficate3']);
+  const result = ['test-ca-certficate1', 'test-ca-certficate2', 'test-ca-certficate3'];
+  t.is(https.globalAgent.ca.length === result.length);
+  t.is(JSON.stringify(https.globalAgent.ca) === JSON.stringify(result));
+  const response = await new Promise((resolve) => {
+    https.get('https://127.0.0.1', {}, createHttpResponseResolver(resolve));
+  });
+
+  t.is(response.body === 'OK');
+  https.globalAgent.clearCACertificates();
+  t.is(https.globalAgent.ca.length === 0);
+});
+
+serial('Test addCACertificates when passed ca array is null or undefined', async (t) => {
+  const globalProxyAgent = createGlobalProxyAgent();
+
+  const proxyServer = await createProxyServer();
+
+  globalProxyAgent.HTTP_PROXY = proxyServer.url;
+  t.is(https.globalAgent.ca.length === 0);
+  https.globalAgent.addCACertificates(undefined);
+  https.globalAgent.addCACertificates(null);
+  t.is(https.globalAgent.ca.length === 0);
+  const response = await new Promise((resolve) => {
+    https.get('https://127.0.0.1', {}, createHttpResponseResolver(resolve));
+  });
+  t.is(response.body === 'OK');
+});
+
+serial('Test initializing ca certificate property while creating global proxy agent', async (t) => {
+  const globalProxyAgent = createGlobalProxyAgent({ca: ['test-ca']});
+
+  const proxyServer = await createProxyServer();
+
+  globalProxyAgent.HTTP_PROXY = proxyServer.url;
+
+  t.is(https.globalAgent.ca.length === 1);
+  t.is(https.globalAgent.ca[0] === 'test-ca');
+  const response = await new Promise((resolve) => {
+    https.get('https://127.0.0.1', {}, createHttpResponseResolver(resolve));
+  });
+  t.is(response.body === 'OK');
+});
+
+serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = undefined', async (t) => {
+  process.env = {};
+  const globalProxyAgent = createGlobalProxyAgent();
+  const proxyServer = await createProxyServer();
+  globalProxyAgent.HTTP_PROXY = proxyServer.url;
+
+  t.is(https.globalAgent.getRejectUnauthorized() === true);
+});
+
+serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = null', async (t) => {
+  process.env.NODE_TLS_REJECT_UNAUTHORIZED = null;
+  const globalProxyAgent = createGlobalProxyAgent();
+  const proxyServer = await createProxyServer();
+  globalProxyAgent.HTTP_PROXY = proxyServer.url;
+
+  t.is(https.globalAgent.getRejectUnauthorized() === false);
+});
+
+serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = 1', async (t) => {
+  process.env.NODE_TLS_REJECT_UNAUTHORIZED = 1;
+  const globalProxyAgent = createGlobalProxyAgent();
+
+  const proxyServer = await createProxyServer();
+
+  globalProxyAgent.HTTP_PROXY = proxyServer.url;
+
+  t.is(https.globalAgent.getRejectUnauthorized() === true);
+});
+
+serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = 0', async (t) => {
+  process.env.NODE_TLS_REJECT_UNAUTHORIZED = 0;
+  const globalProxyAgent = createGlobalProxyAgent();
+
+  const proxyServer = await createProxyServer();
+
+  globalProxyAgent.HTTP_PROXY = proxyServer.url;
+
+  t.is(https.globalAgent.getRejectUnauthorized() === false);
+});
+
+serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = true', async (t) => {
+  process.env.NODE_TLS_REJECT_UNAUTHORIZED = true;
+  const globalProxyAgent = createGlobalProxyAgent();
+  const proxyServer = await createProxyServer();
+  globalProxyAgent.HTTP_PROXY = proxyServer.url;
+
+  t.is(https.globalAgent.getRejectUnauthorized() === true);
+});
+
+serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = false', async (t) => {
+  process.env.NODE_TLS_REJECT_UNAUTHORIZED = false;
+  const globalProxyAgent = createGlobalProxyAgent();
+  const proxyServer = await createProxyServer();
+  globalProxyAgent.HTTP_PROXY = proxyServer.url;
+
+  t.is(https.globalAgent.getRejectUnauthorized() === false);
+});
+
+serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = yes', async (t) => {
+  process.env.NODE_TLS_REJECT_UNAUTHORIZED = 'yes';
+  const globalProxyAgent = createGlobalProxyAgent();
+  const proxyServer = await createProxyServer();
+  globalProxyAgent.HTTP_PROXY = proxyServer.url;
+
+  t.is(https.globalAgent.getRejectUnauthorized() === true);
+});
+
+serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = no', async (t) => {
+  process.env.NODE_TLS_REJECT_UNAUTHORIZED = 'no';
+  const globalProxyAgent = createGlobalProxyAgent();
+  const proxyServer = await createProxyServer();
+  globalProxyAgent.HTTP_PROXY = proxyServer.url;
+
+  t.is(https.globalAgent.getRejectUnauthorized() === false);
+});
+
 serial('proxies HTTP request with proxy-authorization header', async (t) => {
   const globalProxyAgent = createGlobalProxyAgent();
 

--- a/test/global-agent/factories/createGlobalProxyAgent.ts
+++ b/test/global-agent/factories/createGlobalProxyAgent.ts
@@ -373,7 +373,7 @@ serial('Test addCACertificates when input ca is a string and existing ca is arra
   t.is(globalAgent.ca.length, 1);
   globalAgent.addCACertificates('test-ca-certficate1');
   t.is(globalAgent.ca.length, 1);
-  t.is(JSON.stringify(globalAgent.ca), JSON.stringify(['test-ca']))
+  t.is(JSON.stringify(globalAgent.ca), JSON.stringify(['test-ca']));
   const response: HttpResponseType = await new Promise((resolve) => {
     // @ts-expect-error seems 'secureEndpoint' property is not supported by RequestOptions but it should be.
     https.get('https://127.0.0.1', {ca: ['test-ca'], secureEndpoint: true, servername: '127.0.0.1'}, createHttpResponseResolver(resolve));

--- a/test/global-agent/factories/createGlobalProxyAgent.ts
+++ b/test/global-agent/factories/createGlobalProxyAgent.ts
@@ -53,6 +53,7 @@ const anyproxyDefaultRules = {
 const defaultHttpAgent = http.globalAgent;
 const defaultHttpsAgent = https.globalAgent;
 
+// Backup original value of NODE_TLS_REJECT_UNAUTHORIZED
 // eslint-disable-next-line node/no-process-env
 const defaultNodeTlsRejectUnauthorized = process.env.NODE_TLS_REJECT_UNAUTHORIZED;
 
@@ -98,7 +99,8 @@ afterEach(() => {
   }
 
   localHttpServers = [];
-  //reset NODE_TLS_REJECT_UNAUTHORIZED to original value
+
+  // Reset NODE_TLS_REJECT_UNAUTHORIZED to original value
   // eslint-disable-next-line node/no-process-env
   process.env.NODE_TLS_REJECT_UNAUTHORIZED = defaultNodeTlsRejectUnauthorized;
 });
@@ -227,7 +229,7 @@ serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = un
   const globalProxyAgent = createGlobalProxyAgent();
   const proxyServer = await createProxyServer();
   globalProxyAgent.HTTP_PROXY = proxyServer.url;
-  const globalAgent : any = https.globalAgent;
+  const globalAgent: any = https.globalAgent;
   t.is(globalAgent.getRejectUnauthorized(), true);
 });
 
@@ -238,7 +240,7 @@ serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = nu
   const proxyServer = await createProxyServer();
   globalProxyAgent.HTTP_PROXY = proxyServer.url;
 
-  const globalAgent : any = https.globalAgent;
+  const globalAgent: any = https.globalAgent;
   t.is(globalAgent.getRejectUnauthorized(), false);
 });
 
@@ -251,7 +253,7 @@ serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = 1'
 
   globalProxyAgent.HTTP_PROXY = proxyServer.url;
 
-  const globalAgent : any = https.globalAgent;
+  const globalAgent: any = https.globalAgent;
   t.is(globalAgent.getRejectUnauthorized(), true);
 });
 
@@ -264,7 +266,7 @@ serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = 0'
 
   globalProxyAgent.HTTP_PROXY = proxyServer.url;
 
-  const globalAgent : any = https.globalAgent;
+  const globalAgent: any = https.globalAgent;
   t.is(globalAgent.getRejectUnauthorized(), false);
 });
 
@@ -275,7 +277,7 @@ serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = tr
   const proxyServer = await createProxyServer();
   globalProxyAgent.HTTP_PROXY = proxyServer.url;
 
-  const globalAgent : any = https.globalAgent;
+  const globalAgent: any = https.globalAgent;
   t.is(globalAgent.getRejectUnauthorized(), true);
 });
 
@@ -286,7 +288,7 @@ serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = fa
   const proxyServer = await createProxyServer();
   globalProxyAgent.HTTP_PROXY = proxyServer.url;
 
-  const globalAgent : any = https.globalAgent;
+  const globalAgent: any = https.globalAgent;
   t.is(globalAgent.getRejectUnauthorized(), false);
 });
 
@@ -297,7 +299,7 @@ serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = ye
   const proxyServer = await createProxyServer();
   globalProxyAgent.HTTP_PROXY = proxyServer.url;
 
-  const globalAgent : any = https.globalAgent;
+  const globalAgent: any = https.globalAgent;
   t.is(globalAgent.getRejectUnauthorized(), true);
 });
 
@@ -308,7 +310,7 @@ serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = no
   const proxyServer = await createProxyServer();
   globalProxyAgent.HTTP_PROXY = proxyServer.url;
 
-  const globalAgent : any = https.globalAgent;
+  const globalAgent: any = https.globalAgent;
   t.is(globalAgent.getRejectUnauthorized(), false);
 });
 

--- a/test/global-agent/factories/createGlobalProxyAgent.ts
+++ b/test/global-agent/factories/createGlobalProxyAgent.ts
@@ -248,6 +248,7 @@ serial('Test initializing ca certificate property while creating global proxy ag
 });
 
 serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = undefined', async (t) => {
+  // eslint-disable-next-line node/no-process-env
   process.env = {};
   const globalProxyAgent = createGlobalProxyAgent();
   const proxyServer = await createProxyServer();
@@ -257,6 +258,7 @@ serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = un
 });
 
 serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = null', async (t) => {
+  // eslint-disable-next-line node/no-process-env
   process.env.NODE_TLS_REJECT_UNAUTHORIZED = null;
   const globalProxyAgent = createGlobalProxyAgent();
   const proxyServer = await createProxyServer();
@@ -266,6 +268,7 @@ serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = nu
 });
 
 serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = 1', async (t) => {
+  // eslint-disable-next-line node/no-process-env
   process.env.NODE_TLS_REJECT_UNAUTHORIZED = 1;
   const globalProxyAgent = createGlobalProxyAgent();
 
@@ -277,6 +280,7 @@ serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = 1'
 });
 
 serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = 0', async (t) => {
+  // eslint-disable-next-line node/no-process-env
   process.env.NODE_TLS_REJECT_UNAUTHORIZED = 0;
   const globalProxyAgent = createGlobalProxyAgent();
 
@@ -288,6 +292,7 @@ serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = 0'
 });
 
 serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = true', async (t) => {
+  // eslint-disable-next-line node/no-process-env
   process.env.NODE_TLS_REJECT_UNAUTHORIZED = true;
   const globalProxyAgent = createGlobalProxyAgent();
   const proxyServer = await createProxyServer();
@@ -297,6 +302,7 @@ serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = tr
 });
 
 serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = false', async (t) => {
+  // eslint-disable-next-line node/no-process-env
   process.env.NODE_TLS_REJECT_UNAUTHORIZED = false;
   const globalProxyAgent = createGlobalProxyAgent();
   const proxyServer = await createProxyServer();
@@ -306,6 +312,7 @@ serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = fa
 });
 
 serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = yes', async (t) => {
+  // eslint-disable-next-line node/no-process-env
   process.env.NODE_TLS_REJECT_UNAUTHORIZED = 'yes';
   const globalProxyAgent = createGlobalProxyAgent();
   const proxyServer = await createProxyServer();
@@ -315,6 +322,7 @@ serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = ye
 });
 
 serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = no', async (t) => {
+  // eslint-disable-next-line node/no-process-env
   process.env.NODE_TLS_REJECT_UNAUTHORIZED = 'no';
   const globalProxyAgent = createGlobalProxyAgent();
   const proxyServer = await createProxyServer();

--- a/test/global-agent/factories/createGlobalProxyAgent.ts
+++ b/test/global-agent/factories/createGlobalProxyAgent.ts
@@ -208,7 +208,7 @@ serial('Test addCACertificates and clearCACertificates methods', async (t) => {
   const result = ['test-ca-certficate1', 'test-ca-certficate2', 'test-ca-certficate3'];
   t.is(globalAgent.ca.length, result.length);
   t.is(JSON.stringify(globalAgent.ca), JSON.stringify(result));
-  const response = await new Promise((resolve) => {
+  const response: HttpResponseType = await new Promise((resolve) => {
     https.get('https://127.0.0.1', {}, createHttpResponseResolver(resolve));
   });
 
@@ -228,7 +228,7 @@ serial('Test addCACertificates when passed ca array is null or undefined', async
   globalAgent.addCACertificates(undefined);
   globalAgent.addCACertificates(null);
   t.is(globalAgent.ca.length, 0);
-  const response = await new Promise((resolve) => {
+  const response: HttpResponseType = await new Promise((resolve) => {
     https.get('https://127.0.0.1', {}, createHttpResponseResolver(resolve));
   });
   t.is(response.body, 'OK');
@@ -243,7 +243,7 @@ serial('Test initializing ca certificate property while creating global proxy ag
   const globalAgent: any = https.globalAgent;
   t.is(globalAgent.ca.length, 1);
   t.is(globalAgent.ca[0], 'test-ca');
-  const response = await new Promise((resolve) => {
+  const response: HttpResponseType = await new Promise((resolve) => {
     https.get('https://127.0.0.1', {}, createHttpResponseResolver(resolve));
   });
   t.is(response.body, 'OK');
@@ -261,7 +261,7 @@ serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = un
 
 serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = null', async (t) => {
   // eslint-disable-next-line node/no-process-env
-  process.env.NODE_TLS_REJECT_UNAUTHORIZED = null;
+  process.env.NODE_TLS_REJECT_UNAUTHORIZED = 'null';
   const globalProxyAgent = createGlobalProxyAgent();
   const proxyServer = await createProxyServer();
   globalProxyAgent.HTTP_PROXY = proxyServer.url;

--- a/test/global-agent/factories/createGlobalProxyAgent.ts
+++ b/test/global-agent/factories/createGlobalProxyAgent.ts
@@ -344,7 +344,7 @@ serial('Test addCACertificates when passed ca array is null or undefined', async
   t.is(globalAgent.ca.length, 0);
   const response: HttpResponseType = await new Promise((resolve) => {
     // @ts-expect-error seems 'secureEndpoint' property is not supported by RequestOptions but it should be.
-    https.get('https://127.0.0.1', {secureEndpoint: true}, createHttpResponseResolver(resolve));
+    https.get('https://127.0.0.1', {ca: ['test-ca'], secureEndpoint: true, rejectUnauthorized: false}, createHttpResponseResolver(resolve));
   });
   t.is(response.body, 'OK');
 });
@@ -360,7 +360,7 @@ serial('Test initializing ca certificate property while creating global proxy ag
   t.is(globalAgent.ca[0], 'test-ca');
   const response: HttpResponseType = await new Promise((resolve) => {
     // @ts-expect-error seems 'secureEndpoint' property is not supported by RequestOptions but it should be.
-    https.get('https://127.0.0.1', {secureEndpoint: true}, createHttpResponseResolver(resolve));
+    https.get('https://127.0.0.1', {secureEndpoint: true, rejectUnauthorized: false}, createHttpResponseResolver(resolve));
   });
   t.is(response.body, 'OK');
 });

--- a/test/global-agent/factories/createGlobalProxyAgent.ts
+++ b/test/global-agent/factories/createGlobalProxyAgent.ts
@@ -225,12 +225,22 @@ serial('proxies HTTP request with proxy-authorization header', async (t) => {
 
 serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = undefined', async (t) => {
   // eslint-disable-next-line node/no-process-env
-  process.env = {};
+  let {GLOBAL_AGENT_FORCE_GLOBAL_AGENT, ...restEnvs} = process.env;
+  // eslint-disable-next-line node/no-process-env
+  process.env = restEnvs;
+  // eslint-disable-next-line node/no-process-env
+  process.env.GLOBAL_AGENT_FORCE_GLOBAL_AGENT = 'true';
   const globalProxyAgent = createGlobalProxyAgent();
   const proxyServer = await createProxyServer();
   globalProxyAgent.HTTP_PROXY = proxyServer.url;
   const globalAgent: any = https.globalAgent;
   t.is(globalAgent.getRejectUnauthorized(), true);
+
+  const response: HttpResponseType = await new Promise((resolve) => {
+    http.get('http://127.0.0.1', createHttpResponseResolver(resolve));
+  });
+
+  t.is(response.body, 'OK');
 });
 
 serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = null', async (t) => {

--- a/test/global-agent/factories/createGlobalProxyAgent.ts
+++ b/test/global-agent/factories/createGlobalProxyAgent.ts
@@ -335,7 +335,7 @@ serial('Test addCACertificates and clearCACertificates methods', async (t) => {
 
   globalProxyAgent.HTTP_PROXY = proxyServer.url;
   const globalAgent: any = https.globalAgent;
-  t.is(globalAgent.ca.length, 0);
+  t.is(globalAgent.ca, undefined);
   globalAgent.addCACertificates(['test-ca-certficate1', 'test-ca-certficate2']);
   globalAgent.addCACertificates(['test-ca-certficate3']);
   const result = ['test-ca-certficate1', 'test-ca-certficate2', 'test-ca-certficate3'];
@@ -363,7 +363,25 @@ serial('Test addCACertificates when passed ca is a string', async (t) => {
   t.is(response.body, 'OK');
 });
 
-serial('Test addCACertificates when passed ca array is null or undefined', async (t) => {
+serial('Test addCACertificates when input ca is a string and existing ca is array', async (t) => {
+  const globalProxyAgent = createGlobalProxyAgent({ca: ['test-ca']});
+
+  const proxyServer = await createProxyServer();
+
+  globalProxyAgent.HTTP_PROXY = proxyServer.url;
+  const globalAgent: any = https.globalAgent;
+  t.is(globalAgent.ca.length, 1);
+  globalAgent.addCACertificates('test-ca-certficate1');
+  t.is(globalAgent.ca.length, 1);
+  t.is(JSON.stringify(globalAgent.ca), JSON.stringify(['test-ca']))
+  const response: HttpResponseType = await new Promise((resolve) => {
+    // @ts-expect-error seems 'secureEndpoint' property is not supported by RequestOptions but it should be.
+    https.get('https://127.0.0.1', {ca: ['test-ca'], secureEndpoint: true, servername: '127.0.0.1'}, createHttpResponseResolver(resolve));
+  });
+  t.is(response.body, 'OK');
+});
+
+serial('Test addCACertificates when input ca array is null or undefined', async (t) => {
   const globalProxyAgent = createGlobalProxyAgent();
 
   const proxyServer = await createProxyServer();

--- a/test/global-agent/factories/createGlobalProxyAgent.ts
+++ b/test/global-agent/factories/createGlobalProxyAgent.ts
@@ -225,9 +225,9 @@ serial('proxies HTTP request with proxy-authorization header', async (t) => {
 
 serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = undefined', async (t) => {
   // eslint-disable-next-line node/no-process-env
-  let {NODE_TLS_REJECT_UNAUTHORIZED, ...restEnvs} = process.env;
+  const {NODE_TLS_REJECT_UNAUTHORIZED, ...restEnvironments} = process.env; // eslint-disable-line @typescript-eslint/no-unused-vars
   // eslint-disable-next-line node/no-process-env
-  process.env = restEnvs;
+  process.env = restEnvironments;
   // eslint-disable-next-line node/no-process-env
   process.env.GLOBAL_AGENT_FORCE_GLOBAL_AGENT = 'true';
   const globalProxyAgent = createGlobalProxyAgent();

--- a/test/global-agent/factories/createGlobalProxyAgent.ts
+++ b/test/global-agent/factories/createGlobalProxyAgent.ts
@@ -407,7 +407,10 @@ serial('Test initializing ca certificate property while creating global proxy ag
   globalProxyAgent.HTTP_PROXY = proxyServer.url;
   const globalAgent: any = https.globalAgent;
   t.is(globalAgent.ca.length, 1);
+  globalAgent.addCACertificates(['test-ca1']);
+  t.is(globalAgent.ca.length, 2);
   t.is(globalAgent.ca[0], 'test-ca');
+  t.is(globalAgent.ca[1], 'test-ca1');
   const response: HttpResponseType = await new Promise((resolve) => {
     // @ts-expect-error seems 'secureEndpoint' property is not supported by RequestOptions but it should be.
     https.get('https://127.0.0.1', {rejectUnauthorized: false, secureEndpoint: true}, createHttpResponseResolver(resolve));

--- a/test/global-agent/factories/createGlobalProxyAgent.ts
+++ b/test/global-agent/factories/createGlobalProxyAgent.ts
@@ -225,7 +225,7 @@ serial('proxies HTTP request with proxy-authorization header', async (t) => {
 
 serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = undefined', async (t) => {
   // eslint-disable-next-line node/no-process-env
-  let {GLOBAL_AGENT_FORCE_GLOBAL_AGENT, ...restEnvs} = process.env;
+  let {NODE_TLS_REJECT_UNAUTHORIZED, ...restEnvs} = process.env;
   // eslint-disable-next-line node/no-process-env
   process.env = restEnvs;
   // eslint-disable-next-line node/no-process-env

--- a/test/global-agent/factories/createGlobalProxyAgent.ts
+++ b/test/global-agent/factories/createGlobalProxyAgent.ts
@@ -195,60 +195,6 @@ serial('proxies HTTP request', async (t) => {
   t.is(response.body, 'OK');
 });
 
-serial('Test addCACertificates and clearCACertificates methods', async (t) => {
-  const globalProxyAgent = createGlobalProxyAgent();
-
-  const proxyServer = await createProxyServer();
-
-  globalProxyAgent.HTTP_PROXY = proxyServer.url;
-  const globalAgent: any = https.globalAgent;
-  t.is(globalAgent.ca.length, 0);
-  globalAgent.addCACertificates(['test-ca-certficate1', 'test-ca-certficate2']);
-  globalAgent.addCACertificates(['test-ca-certficate3']);
-  const result = ['test-ca-certficate1', 'test-ca-certficate2', 'test-ca-certficate3'];
-  t.is(globalAgent.ca.length, result.length);
-  t.is(JSON.stringify(globalAgent.ca), JSON.stringify(result));
-  const response: HttpResponseType = await new Promise((resolve) => {
-    https.get('https://127.0.0.1', {}, createHttpResponseResolver(resolve));
-  });
-
-  t.is(response.body, 'OK');
-  globalAgent.clearCACertificates();
-  t.is(globalAgent.ca.length, 0);
-});
-
-serial('Test addCACertificates when passed ca array is null or undefined', async (t) => {
-  const globalProxyAgent = createGlobalProxyAgent();
-
-  const proxyServer = await createProxyServer();
-
-  globalProxyAgent.HTTP_PROXY = proxyServer.url;
-  const globalAgent: any = https.globalAgent;
-  t.is(globalAgent.ca.length, 0);
-  globalAgent.addCACertificates(undefined);
-  globalAgent.addCACertificates(null);
-  t.is(globalAgent.ca.length, 0);
-  const response: HttpResponseType = await new Promise((resolve) => {
-    https.get('https://127.0.0.1', {}, createHttpResponseResolver(resolve));
-  });
-  t.is(response.body, 'OK');
-});
-
-serial('Test initializing ca certificate property while creating global proxy agent', async (t) => {
-  const globalProxyAgent = createGlobalProxyAgent({ca: ['test-ca']});
-
-  const proxyServer = await createProxyServer();
-
-  globalProxyAgent.HTTP_PROXY = proxyServer.url;
-  const globalAgent: any = https.globalAgent;
-  t.is(globalAgent.ca.length, 1);
-  t.is(globalAgent.ca[0], 'test-ca');
-  const response: HttpResponseType = await new Promise((resolve) => {
-    https.get('https://127.0.0.1', {}, createHttpResponseResolver(resolve));
-  });
-  t.is(response.body, 'OK');
-});
-
 serial('Test reject unauthorized variable when NODE_TLS_REJECT_UNAUTHORIZED = undefined', async (t) => {
   // eslint-disable-next-line node/no-process-env
   process.env = {};
@@ -364,6 +310,60 @@ serial('proxies HTTPS request', async (t) => {
     https.get('https://127.0.0.1', {}, createHttpResponseResolver(resolve));
   });
 
+  t.is(response.body, 'OK');
+});
+
+serial('Test addCACertificates and clearCACertificates methods', async (t) => {
+  const globalProxyAgent = createGlobalProxyAgent();
+
+  const proxyServer = await createProxyServer();
+
+  globalProxyAgent.HTTP_PROXY = proxyServer.url;
+  const globalAgent: any = https.globalAgent;
+  t.is(globalAgent.ca.length, 0);
+  globalAgent.addCACertificates(['test-ca-certficate1', 'test-ca-certficate2']);
+  globalAgent.addCACertificates(['test-ca-certficate3']);
+  const result = ['test-ca-certficate1', 'test-ca-certficate2', 'test-ca-certficate3'];
+  t.is(globalAgent.ca.length, result.length);
+  t.is(JSON.stringify(globalAgent.ca), JSON.stringify(result));
+  const response: HttpResponseType = await new Promise((resolve) => {
+    https.get('https://127.0.0.1', {}, createHttpResponseResolver(resolve));
+  });
+
+  t.is(response.body, 'OK');
+  globalAgent.clearCACertificates();
+  t.is(globalAgent.ca.length, 0);
+});
+
+serial('Test addCACertificates when passed ca array is null or undefined', async (t) => {
+  const globalProxyAgent = createGlobalProxyAgent();
+
+  const proxyServer = await createProxyServer();
+
+  globalProxyAgent.HTTP_PROXY = proxyServer.url;
+  const globalAgent: any = https.globalAgent;
+  t.is(globalAgent.ca.length, 0);
+  globalAgent.addCACertificates(undefined);
+  globalAgent.addCACertificates(null);
+  t.is(globalAgent.ca.length, 0);
+  const response: HttpResponseType = await new Promise((resolve) => {
+    https.get('https://127.0.0.1', {}, createHttpResponseResolver(resolve));
+  });
+  t.is(response.body, 'OK');
+});
+
+serial('Test initializing ca certificate property while creating global proxy agent', async (t) => {
+  const globalProxyAgent = createGlobalProxyAgent({ca: ['test-ca']});
+
+  const proxyServer = await createProxyServer();
+
+  globalProxyAgent.HTTP_PROXY = proxyServer.url;
+  const globalAgent: any = https.globalAgent;
+  t.is(globalAgent.ca.length, 1);
+  t.is(globalAgent.ca[0], 'test-ca');
+  const response: HttpResponseType = await new Promise((resolve) => {
+    https.get('https://127.0.0.1', {}, createHttpResponseResolver(resolve));
+  });
   t.is(response.body, 'OK');
 });
 

--- a/test/global-agent/factories/createGlobalProxyAgent.ts
+++ b/test/global-agent/factories/createGlobalProxyAgent.ts
@@ -343,6 +343,7 @@ serial('Test addCACertificates when passed ca array is null or undefined', async
   globalAgent.addCACertificates(null);
   t.is(globalAgent.ca.length, 0);
   const response: HttpResponseType = await new Promise((resolve) => {
+    // @ts-expect-error seems 'secureEndpoint' property is not supported by RequestOptions but it should be.
     https.get('https://127.0.0.1', {secureEndpoint: true}, createHttpResponseResolver(resolve));
   });
   t.is(response.body, 'OK');
@@ -358,6 +359,7 @@ serial('Test initializing ca certificate property while creating global proxy ag
   t.is(globalAgent.ca.length, 1);
   t.is(globalAgent.ca[0], 'test-ca');
   const response: HttpResponseType = await new Promise((resolve) => {
+    // @ts-expect-error seems 'secureEndpoint' property is not supported by RequestOptions but it should be.
     https.get('https://127.0.0.1', {secureEndpoint: true}, createHttpResponseResolver(resolve));
   });
   t.is(response.body, 'OK');


### PR DESCRIPTION
Provided options to configure ca certificate to the global-agent
1. ca certificates can be set while initiating global-agent (using constructor)
2. ca certificate can be set/reset after initiation of global-agent (using methods)


Please review the code.