### PR TITLE
docs: fix table heading for GLOBAL_AGENT properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ type ProxyAgentConfigurationInputType = {|
 
 `global.GLOBAL_AGENT` has the following properties:
 
-|Name|Description|Configurable|
+|Name|Configurable|Description|
 |---|---|---|
 |`HTTP_PROXY`|Yes|Sets HTTP proxy to use.|
 |`HTTPS_PROXY`|Yes|Sets a distinct proxy to use for HTTPS requests.|


### PR DESCRIPTION
It looks like for some reason the "Configurable" and "Description" headings were somehow swapped in the table describing `global.GLOBAL_AGENT` object's properties. This PR swaps them to the correct order.