### PR TITLE
Fix for direct CONNECT requests

### DIFF
--- a/src/classes/Agent.ts
+++ b/src/classes/Agent.ts
@@ -76,6 +76,8 @@ abstract class Agent {
     // https://gist.github.com/gajus/e2074cd3b747864ffeaabbd530d30218
     if (request.path.startsWith('http://') ?? request.path.startsWith('https://')) {
       requestUrl = request.path;
+    } else if (request.method === 'CONNECT') {
+      requestUrl = 'https://' + request.path;
     } else {
       requestUrl = this.protocol + '//' + (configuration.hostname ?? configuration.host) + (configuration.port === 80 ?? configuration.port === 443 ? '' : ':' + configuration.port) + request.path;
     }


### PR DESCRIPTION
Fix handling for direct HTTP `CONNECT` requests sent using the `http` modules with global-agent installed

Contributed by courtesy of [swimm.io](https://swimm.io/)