### PR TITLE
chore(deps): remove boolean dependency and inline parseBoolean

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     ]
   },
   "dependencies": {
-    "boolean": "^3.1.2",
     "es6-error": "^4.1.1",
     "globalthis": "^1.0.2",
     "matcher": "^4.0.0",

--- a/src/factories/createGlobalProxyAgent.ts
+++ b/src/factories/createGlobalProxyAgent.ts
@@ -1,8 +1,23 @@
 import http from 'http';
 import https from 'https';
-import {
-  boolean as parseBoolean,
-} from 'boolean';
+// Lightweight parseBoolean to avoid a small third-party dependency 'boolean'
+function parseBoolean(value: unknown): boolean {
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'number') return value !== 0;
+  if (typeof value === 'string') {
+    switch (value.trim().toLowerCase()) {
+      case '1':
+      case 'true':
+      case 'yes':
+      case 'y':
+      case 'on':
+        return true;
+      default:
+        return false;
+    }
+  }
+  return Boolean(value);
+}
 import {
   omitUndefined,
 } from 'omit-undefined';


### PR DESCRIPTION
This PR inlines a simple parseBoolean helper and removes the boolean dependency. This reduces small transitive dependency maintenance footprints. Tests: basic test runs completed locally, with some network-dependent tests timing out in CI simulation. Please run the full pipeline upstream.