### PR TITLE
fix: drop wrong typings property

### DIFF
--- a/.github/workflows/feature.yaml
+++ b/.github/workflows/feature.yaml
@@ -14,10 +14,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-      - name: setup npm
-        uses: npm/action-setup@v4
-        with:
-          version: 10
+     
       - run: npm install
       - run: npm run lint
       - run: npm run test

--- a/package.json
+++ b/package.json
@@ -71,6 +71,5 @@
     "test": "vitest run",
     "create-readme": "gitdown ./.README/README.md --output-file ./README.md"
   },
-  "typings": "./dist/src/index.d.ts",
   "version": "0.0.0-development"
 }


### PR DESCRIPTION
- closes #80

the property points to wrong file and isn't required. typescript is smart enough to find typings 