### PR TITLE
fix: always set TLS servername for HTTPS proxy connections

### DIFF
--- a/src/classes/Agent.ts
+++ b/src/classes/Agent.ts
@@ -223,8 +223,10 @@ abstract class Agent {
     // > are also accepted:
     // >   ca, cert, ciphers, clientCertEngine, crl, dhparam, ecdhCurve, honorCipherOrder,
     // >   key, passphrase, pfx, rejectUnauthorized, secureOptions, secureProtocol, servername, sessionIdContext.
-    if (configuration.secureEndpoint) {
-      // Determine servername - Node.js doesn't allow IP addresses as servername
+    // Use `this.protocol` instead of `configuration.secureEndpoint` to determine
+    // if TLS options are needed. Many HTTP clients (got@11, etc.) don't set
+    // `secureEndpoint`, causing TLS connections to omit servername (SNI).
+    if (this.protocol === 'https:' || configuration.secureEndpoint) {
       const host = configuration.servername ?? connectionConfiguration.host;
       const servername = net.isIP(host) ? undefined : host;
 


### PR DESCRIPTION
Related issues: [#83](https://github.com/gajus/global-agent/issues/83), [#62](https://github.com/gajus/global-agent/issues/62)

When using `HttpsProxyAgent` via a CONNECT proxy, TLS options (including `servername` for SNI) are only set when `configuration.secureEndpoint` is truthy. However, many popular HTTP clients (notably `got@11`, which uses Node's built-in `https.request`) do **not** set `secureEndpoint` in the options passed to the agent's `addRequest` method.

This causes `tls.connect()` to be called without `servername`, meaning no SNI extension is sent in the TLS ClientHello. Servers behind CDNs (e.g. CloudFront, Cloudflare) that require SNI to route to the correct certificate reject the handshake with:

```
Error: write EPROTO ... ssl/tls alert handshake failure ... SSL alert number 40
```

### Root cause

In `Agent.ts`, the TLS configuration block is gated by:

```typescript
if (configuration.secureEndpoint) {   // ← NOT set by got@11, axios, etc.
    connectionConfiguration.tls = {
        servername,                    // ← never reaches here
        ...
    };
}
```

The `secureEndpoint` property is a convention from `agent-base` / `pac-proxy-agent`, but standard Node.js `https.request()` and libraries like `got@11` never set it.

### Fix

Change the condition from `configuration.secureEndpoint` to `this.protocol === 'https:'`. Since `HttpsProxyAgent` always sets `this.protocol = 'https:'`, TLS options will always be configured when the agent is used for HTTPS connections, regardless of whether the caller sets `secureEndpoint`.

## Reproduction

```bash
# Requires an HTTP CONNECT proxy at $PROXY_HOST:$PROXY_PORT
node -e "
process.env.GLOBAL_AGENT_ENVIRONMENT_VARIABLE_NAMESPACE = '';
process.env.GLOBAL_AGENT_FORCE_GLOBAL_AGENT = 'false';
process.env.HTTPS_PROXY = 'http://\$PROXY_HOST:\$PROXY_PORT';
require('global-agent').bootstrap();

const got = require('got');
(async () => {
  try {
    // Any HTTPS host behind a CDN requiring SNI
    const r = await got('https://api.sensible.so/v0', {throwHttpErrors:false, timeout:{request:10000}});
    console.log('OK:', r.statusCode);
  } catch(e) {
    console.log('FAIL:', e.code, e.message);
    // Without fix: EPROTO ssl/tls alert handshake failure SSL alert number 40
    // With fix:    OK: 403
  }
})();
"
```

## Verified fix

Tested with:
- `global-agent@4.1.3` + `got@11.8.6` through HTTP CONNECT proxy
- Node v25.9.0 (OpenSSL 3.6.2)
- Node v22.22.2 (OpenSSL 3.5.5)
- Targets: `api.sensible.so`, `s3.amazonaws.com`
