### PR TITLE
fix: correct typings entrypoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,6 @@
     "test": "vitest run",
     "create-readme": "gitdown ./.README/README.md --output-file ./README.md"
   },
-  "typings": "./dist/src/index.d.ts",
+  "typings": "./dist/index.d.ts",
   "version": "0.0.0-development"
 }


### PR DESCRIPTION
## Summary
- update the package `typings` entry to point at `./dist/index.d.ts`
- the published package contains `dist/index.d.ts`, but not `dist/src/index.d.ts`, so the current metadata points TypeScript at a missing declaration file

## Validation
- `npm run build`
- `npm run lint`
- `npm pack --dry-run --json --ignore-scripts`
- explicit local assertion that `package.json` `typings` resolves to an existing generated declaration file

`npm test` was also attempted. The unrelated certificate test suite failed to import because this local Windows environment does not have `openssl` on PATH; the other test files ran and passed before that suite failure.
